### PR TITLE
fix: ordered map when generating object properties

### DIFF
--- a/model-codegen/src/main/java/com/fern/model/codegen/ObjectGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/ObjectGenerator.java
@@ -17,7 +17,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/model-codegen/src/main/java/com/fern/model/codegen/ObjectGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/ObjectGenerator.java
@@ -18,6 +18,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,7 +65,7 @@ public final class ObjectGenerator extends Generator {
                 .addModifiers(OBJECT_INTERFACE_MODIFIERS)
                 .addAnnotations(getAnnotations())
                 .addSuperinterfaces(getSuperInterfaces());
-        Map<ObjectProperty, MethodSpec> methodSpecsByProperty = new HashMap<>();
+        Map<ObjectProperty, MethodSpec> methodSpecsByProperty = new LinkedHashMap<>();
         if (selfInterface.isEmpty()) {
             methodSpecsByProperty.putAll(
                     generatorContext.getImmutablesUtils().getImmutablesPropertyMethods(objectTypeDefinition));


### PR DESCRIPTION
Should fix generating out of order properties (resulting in failed compilation due to staged builders)