### PR TITLE
fix: publish all subprojects

### DIFF
--- a/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
+++ b/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
@@ -101,7 +101,7 @@ public abstract class CodeGenerationResult {
                 + "    id 'maven-publish'\n"
                 + "}\n"
                 + "\n"
-                + "configure(subprojects.findAll {}) {\n"
+                + "subprojects {\n"
                 + "\n"
                 + "    group '" + publishConfig.coordinate() + "'\n"
                 + "    version '" + publishConfig.version() + "'\n"


### PR DESCRIPTION
before
```
configure(subprojects.findAll {})
```
now 
```
subprojects
```