### PR TITLE
fix: generate response as part of endpoint model

### DIFF
--- a/model-codegen/src/main/java/com/fern/model/codegen/ModelGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/ModelGenerator.java
@@ -139,7 +139,7 @@ public final class ModelGenerator {
                             httpEndpoint,
                             generatedInterfaces,
                             () -> httpEndpoint.response().ok().type(),
-                            true);
+                            false);
                     generatedEndpointModel.generatedHttpResponse(responsePayload);
 
                     if (!httpEndpoint.response().failed().errors().isEmpty()) {


### PR DESCRIPTION
previously responses were being named as requests and thus overwriting requests