### PR TITLE
fix: generate settings.gradle with accurate subproject names

### DIFF
--- a/cli/src/main/java/com/fern/java/client/cli/ClientGeneratorCli.java
+++ b/cli/src/main/java/com/fern/java/client/cli/ClientGeneratorCli.java
@@ -208,8 +208,7 @@ public final class ClientGeneratorCli {
 
         writeFileContents(
                 Paths.get(outputDirectory, "settings.gradle"),
-                CodeGenerationResult.getSettingsDotGradle(
-                        fernPluginConfig.customPluginConfig().mode()));
+                CodeGenerationResult.getSettingsDotGradle(fernPluginConfig));
         Path gradleResourcesFolder = Paths.get("/gradle-resources");
         try (Stream<Path> gradleResources = Files.walk(gradleResourcesFolder)) {
             gradleResources.forEach(gradleResource -> {

--- a/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
+++ b/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
@@ -84,14 +84,18 @@ public abstract class CodeGenerationResult {
                 + "}\n";
     }
 
-    public static String getSettingsDotGradle(CustomPluginConfig.Mode mode) {
-        String settingsGradle = "rootProject.name = 'fern-generated-java'\n" + "\n" + "include 'model'\n";
+    public static String getSettingsDotGradle(FernPluginConfig fernPluginConfig) {
+        Mode mode = fernPluginConfig.customPluginConfig().mode();
+        String settingsGradle =
+                "rootProject.name = 'fern-generated-java'\n"
+                        + "\n"
+                        + "include '" + fernPluginConfig.getModelProjectName() + "'\n";
 
         if (mode.equals(Mode.CLIENT_AND_SERVER) || mode.equals(Mode.CLIENT)) {
-            settingsGradle += "include 'client'\n";
+            settingsGradle += "include '" + fernPluginConfig.getClientProjectName() + "'\n";
         }
         if (mode.equals(Mode.CLIENT_AND_SERVER) || mode.equals(Mode.SERVER)) {
-            settingsGradle += "include 'server'\n";
+            settingsGradle += "include '" + fernPluginConfig.getServerProjectName() + "'\n";
         }
         return settingsGradle;
     }

--- a/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
+++ b/cli/src/main/java/com/fern/java/client/cli/CodeGenerationResult.java
@@ -86,10 +86,9 @@ public abstract class CodeGenerationResult {
 
     public static String getSettingsDotGradle(FernPluginConfig fernPluginConfig) {
         Mode mode = fernPluginConfig.customPluginConfig().mode();
-        String settingsGradle =
-                "rootProject.name = 'fern-generated-java'\n"
-                        + "\n"
-                        + "include '" + fernPluginConfig.getModelProjectName() + "'\n";
+        String settingsGradle = "rootProject.name = 'fern-generated-java'\n"
+                + "\n"
+                + "include '" + fernPluginConfig.getModelProjectName() + "'\n";
 
         if (mode.equals(Mode.CLIENT_AND_SERVER) || mode.equals(Mode.CLIENT)) {
             settingsGradle += "include '" + fernPluginConfig.getClientProjectName() + "'\n";


### PR DESCRIPTION
when subproject names are not accurate empty jars would get published 