### PR TITLE
fix: base image has jdk

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:11-jdk-alpine
 
 ARG BUILD_VERSION
 ENV VERSION=$BUILD_VERSION


### PR DESCRIPTION
In order to run `./gradlew publish` we need a JDK to compile the java code