### PR TITLE
fix: abstract service registry takes in services via constructor

### DIFF
--- a/cli/src/eteTest/java/com/fern/java/client/cli/__snapshots__/CliEteTest.snap
+++ b/cli/src/eteTest/java/com/fern/java/client/cli/__snapshots__/CliEteTest.snap
@@ -703,13 +703,11 @@ import com.blog.errors.PostNotFoundErrorExceptionMapper;
 import org.glassfish.jersey.server.ResourceConfig;
 
 public abstract class AbstractServiceRegistry extends ResourceConfig {
-  public AbstractServiceRegistry() {
+  public AbstractServiceRegistry(PostsService postsService) {
     register(DefaultExceptionMapper.class);
     register(PostNotFoundErrorExceptionMapper.class);
-    register(registerPostsService());
+    register(postsService);
   }
-
-  public abstract PostsService registerPostsService();
 }
 
 ]


### PR DESCRIPTION
- previously the services were passed in via overriden methods, but the base class constructor needs to register instances so should be passed in at construction time.