### PR TITLE
fix: make sure primitive aliases compile

### DIFF
--- a/cli/src/eteTest/basic/api/src/blog.yml
+++ b/cli/src/eteTest/basic/api/src/blog.yml
@@ -3,6 +3,7 @@ imports:
 ids:
   - PostId
 types:
+  Age: integer
   BlogPost:
     docs: A blog post
     properties:

--- a/cli/src/eteTest/java/com/fern/java/client/cli/__snapshots__/CliEteTest.snap
+++ b/cli/src/eteTest/java/com/fern/java/client/cli/__snapshots__/CliEteTest.snap
@@ -324,6 +324,39 @@ public final class GetPostError extends WebApplicationException {
 ]
 
 
+basic[api/generated-java/blog-api-model/src/main/java/com/blog/types/Age.java]=[
+package com.blog.types;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fern.java.immutables.AliasImmutablesStyle;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@AliasImmutablesStyle
+@JsonDeserialize(
+    as = ImmutableAge.class
+)
+public abstract class Age {
+  @JsonValue
+  public abstract int value();
+
+  public static Age valueOf(int value) {
+    return ImmutableAge.of(value);
+  }
+
+  @Override
+  public String toString() {
+    return Integer.toString(value());
+  }
+}
+
+]
+
+
 basic[api/generated-java/blog-api-model/src/main/java/com/blog/types/Author.java]=[
 package com.blog.types;
 
@@ -527,7 +560,7 @@ public abstract class PostId {
 
   @Override
   public String toString() {
-    return value().toString();
+    return value();
   }
 }
 

--- a/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
@@ -25,8 +25,10 @@ import com.fern.java.immutables.AliasImmutablesStyle;
 import com.fern.model.codegen.Generator;
 import com.fern.types.AliasTypeDeclaration;
 import com.fern.types.DeclaredTypeName;
+import com.fern.types.PrimitiveType;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
@@ -123,11 +125,64 @@ public final class AliasGenerator extends Generator {
     }
 
     private MethodSpec getToStringMethod() {
+        CodeBlock toStringMethodCodeBlock;
+        if (aliasTypeDeclaration.aliasOf().isPrimitive()) {
+            toStringMethodCodeBlock =
+                    aliasTypeDeclaration.aliasOf().getPrimitive().get().visit(ToStringMethodSpecVisitor.INSTANCE);
+        } else {
+            toStringMethodCodeBlock =
+                    CodeBlock.of("return $L().$L()", IMMUTABLES_VALUE_PROPERTY_NAME, "toString");
+        }
         return MethodSpec.methodBuilder("toString")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
-                .addStatement("return $L().toString()", IMMUTABLES_VALUE_PROPERTY_NAME)
+                .addStatement(toStringMethodCodeBlock)
                 .returns(ClassNameConstants.STRING_CLASS_NAME)
                 .build();
+    }
+
+    private static final class ToStringMethodSpecVisitor implements PrimitiveType.Visitor<CodeBlock> {
+
+        private static final ToStringMethodSpecVisitor INSTANCE = new ToStringMethodSpecVisitor();
+
+        @Override
+        public CodeBlock visitINTEGER() {
+            return CodeBlock.of("return $T.$L($L())", Integer.class, "toString", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitDOUBLE() {
+            return CodeBlock.of("return $T.$L($L())", Double.class, "toString", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitSTRING() {
+            return CodeBlock.of("return $L()", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitBOOLEAN() {
+            return CodeBlock.of("return $T.$L($L())", Boolean.class, "toString", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitLONG() {
+            return CodeBlock.of("return $T.$L($L())", Long.class, "toString", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitDATE_TIME() {
+            return CodeBlock.of("return $L()", IMMUTABLES_VALUE_PROPERTY_NAME);
+        }
+
+        @Override
+        public CodeBlock visitUUID() {
+            return CodeBlock.of("return $L().$L()", IMMUTABLES_VALUE_PROPERTY_NAME, "toString");
+        }
+
+        @Override
+        public CodeBlock visitUnknown(String s) {
+            throw new RuntimeException("Encountered unknown primitive type: " + s);
+        }
     }
 }

--- a/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
@@ -130,8 +130,7 @@ public final class AliasGenerator extends Generator {
             toStringMethodCodeBlock =
                     aliasTypeDeclaration.aliasOf().getPrimitive().get().visit(ToStringMethodSpecVisitor.INSTANCE);
         } else {
-            toStringMethodCodeBlock =
-                    CodeBlock.of("return $L().$L()", IMMUTABLES_VALUE_PROPERTY_NAME, "toString");
+            toStringMethodCodeBlock = CodeBlock.of("return $L().$L()", IMMUTABLES_VALUE_PROPERTY_NAME, "toString");
         }
         return MethodSpec.methodBuilder("toString")
                 .addModifiers(Modifier.PUBLIC)

--- a/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
+++ b/model-codegen/src/main/java/com/fern/model/codegen/types/AliasGenerator.java
@@ -181,8 +181,8 @@ public final class AliasGenerator extends Generator {
         }
 
         @Override
-        public CodeBlock visitUnknown(String s) {
-            throw new RuntimeException("Encountered unknown primitive type: " + s);
+        public CodeBlock visitUnknown(String unknown) {
+            throw new RuntimeException("Encountered unknown primitive type: " + unknown);
         }
     }
 }


### PR DESCRIPTION
`toString` method was wrong for `Integer`, `Double`