### PR TITLE
box primitives in subtype method

### DIFF
--- a/generator-utils/src/main/java/com/fern/java/generators/union/UnionTypeSpecGenerator.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/union/UnionTypeSpecGenerator.java
@@ -171,7 +171,7 @@ public abstract class UnionTypeSpecGenerator {
                     .addModifiers(Modifier.PUBLIC)
                     .returns(ParameterizedTypeName.get(
                             ClassName.get(Optional.class),
-                            subType.getUnionSubTypeTypeName().get()))
+                            subType.getUnionSubTypeTypeName().get().box()))
                     .beginControlFlow("if ($L())", subType.getIsMethodName())
                     .addStatement(
                             "return $T.of((($T) value).$L)",


### PR DESCRIPTION
For the following union 
```yaml
Age: 
  years: int
  second: long
```

the `getYears` method would return `Optional<int>` which would fail to compile. Now, it'll return `Optional<Integer>`.