### PR TITLE
fix: misc query param bug fixes

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -689,7 +689,7 @@ public final class BlogClientImpl implements BlogClient {
             .newBuilder()
             .addPathSegments("posts")
             .addPathSegment(postId);
-    _httpUrlBuilder.addQueryParameter("Optional[dummy]", request.getDummy());
+    _httpUrlBuilder.addQueryParameter("dummy", request.getDummy());
     HttpUrl _httpUrl = _httpUrlBuilder.build();
     RequestBody _requestBody = RequestBody.create("", null);
     Request.Builder _requestBuilder =


### PR DESCRIPTION
- query params are being correctly referenced from wrapper request `request.param().get()`
- non string query params are serialized as a string using `toString()`
- query param wire keys are properly serialized 