### PR TITLE
fix: request body shouldnt be present in okhttp rquest

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -563,7 +563,6 @@ import com.fern.basic.core.ClientOptions;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public final class AuthClientImpl implements AuthClient {
@@ -583,7 +582,7 @@ public final class AuthClientImpl implements AuthClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("GET", RequestBody.create("", null))
+            .method("GET", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {
@@ -819,7 +818,7 @@ public final class BlogClientImpl implements BlogClient {
             .addPathSegment(postId);
     _httpUrlBuilder.addQueryParameter("dummy", request.getDummy());
     HttpUrl _httpUrl = _httpUrlBuilder.build();
-    RequestBody _requestBody = RequestBody.create("", null);
+    RequestBody _requestBody = null;
     Request.Builder _requestBuilder =
         new Request.Builder()
             .url(_httpUrl)
@@ -847,7 +846,7 @@ public final class BlogClientImpl implements BlogClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("GET", RequestBody.create("", null))
+            .method("GET", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {
@@ -2104,7 +2103,7 @@ public final class DummyServiceClientImpl implements DummyServiceClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("GET", RequestBody.create("", null))
+            .method("GET", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {
@@ -2316,7 +2315,7 @@ public final class DeviceClientImpl implements DeviceClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("DELETE", RequestBody.create("", null))
+            .method("DELETE", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {
@@ -2345,7 +2344,7 @@ public final class DeviceClientImpl implements DeviceClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("GET", RequestBody.create("", null))
+            .method("GET", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {
@@ -6819,7 +6818,7 @@ public final class UserClientImpl implements UserClient {
     Request _request =
         new Request.Builder()
             .url(_httpUrl)
-            .method("GET", RequestBody.create("", null))
+            .method("GET", null)
             .headers(Headers.of(clientOptions.headers()))
             .build();
     try {

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
@@ -30,7 +30,6 @@ import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 
 public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
 
@@ -85,9 +84,7 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
                 .add("$T $L = new $T.Builder()\n", Request.class, AbstractEndpointWriter.REQUEST_NAME, Request.class)
                 .indent()
                 .add(".url($L)\n", AbstractEndpointWriter.HTTP_URL_NAME)
-                .add(
-                        ".method($S, null)\n",
-                        httpEndpoint.getMethod().toString())
+                .add(".method($S, null)\n", httpEndpoint.getMethod().toString())
                 .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
                 .add(".build();\n")
                 .unindent()

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
@@ -86,10 +86,8 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
                 .indent()
                 .add(".url($L)\n", AbstractEndpointWriter.HTTP_URL_NAME)
                 .add(
-                        ".method($S, $T.create($S, null))\n",
-                        httpEndpoint.getMethod().toString(),
-                        RequestBody.class,
-                        "")
+                        ".method($S, null)\n",
+                        httpEndpoint.getMethod().toString())
                 .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
                 .add(".build();\n")
                 .unindent()

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -126,7 +126,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
             }
         }
         httpUrlBuilder.addStatement(
-                "$T $L = $L.build()",
+                "$T $L = $L.build()\n",
                 HttpUrl.class,
                 AbstractEndpointWriter.HTTP_URL_NAME,
                 AbstractEndpointWriter.HTTP_URL_BUILDER_NAME);
@@ -184,11 +184,9 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                     .endControlFlow();
         } else {
             requestInitializerBuilder.addStatement(
-                    "$T $L = $T.create($S, null)",
+                    "$T $L = null",
                     RequestBody.class,
-                    AbstractEndpointWriter.REQUEST_BODY_NAME,
-                    RequestBody.class,
-                    "");
+                    AbstractEndpointWriter.REQUEST_BODY_NAME);
         }
         requestInitializerBuilder
                 .add(

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -184,9 +184,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                     .endControlFlow();
         } else {
             requestInitializerBuilder.addStatement(
-                    "$T $L = null",
-                    RequestBody.class,
-                    AbstractEndpointWriter.REQUEST_BODY_NAME);
+                    "$T $L = null", RequestBody.class, AbstractEndpointWriter.REQUEST_BODY_NAME);
         }
         requestInitializerBuilder
                 .add(


### PR DESCRIPTION
We were previously doing `RequestBody.create("", null)` for endpoints that didn't take a request body. Now we pass `null` instead. 