### PR TITLE
fix: send content type header when body is present

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -796,7 +796,8 @@ public final class BlogClientImpl implements BlogClient {
         new Request.Builder()
             .url(_httpUrl)
             .method("POST", _requestBody)
-            .headers(Headers.of(clientOptions.headers()));
+            .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json");
     Request _request = _requestBuilder.build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -823,7 +824,8 @@ public final class BlogClientImpl implements BlogClient {
         new Request.Builder()
             .url(_httpUrl)
             .method("GET", _requestBody)
-            .headers(Headers.of(clientOptions.headers()));
+            .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json");
     Request _request = _requestBuilder.build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2081,6 +2083,7 @@ public final class DummyServiceClientImpl implements DummyServiceClient {
             .url(_httpUrl)
             .method("POST", _requestBody)
             .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json")
             .build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2250,6 +2253,7 @@ public final class DeviceClientImpl implements DeviceClient {
             .url(_httpUrl)
             .method("POST", _requestBody)
             .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json")
             .build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2288,6 +2292,7 @@ public final class DeviceClientImpl implements DeviceClient {
             .url(_httpUrl)
             .method("PUT", _requestBody)
             .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json")
             .build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2960,7 +2965,8 @@ public final class EventClientImpl implements EventClient {
         new Request.Builder()
             .url(_httpUrl)
             .method("POST", _requestBody)
-            .headers(Headers.of(clientOptions.headers()));
+            .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json");
     if (request.getIdempotencyKey().isPresent()) {
       _requestBuilder.addHeader("Idempotency-Key", request.getIdempotencyKey().get());
     }
@@ -3002,7 +3008,8 @@ public final class EventClientImpl implements EventClient {
         new Request.Builder()
             .url(_httpUrl)
             .method("POST", _requestBody)
-            .headers(Headers.of(clientOptions.headers()));
+            .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json");
     if (request.getIdempotencyKey().isPresent()) {
       _requestBuilder.addHeader("Idempotency-Key", request.getIdempotencyKey().get());
     }
@@ -6792,7 +6799,8 @@ public final class UserClientImpl implements UserClient {
         new Request.Builder()
             .url(_httpUrl)
             .method("POST", _requestBody)
-            .headers(Headers.of(clientOptions.headers()));
+            .headers(Headers.of(clientOptions.headers()))
+            .addHeader("Content-Type", "application/json");
     Request _request = _requestBuilder.build();
     try {
       Response _response = clientOptions.httpClient().newCall(_request).execute();

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -45,6 +45,9 @@ import okhttp3.Response;
 
 public abstract class AbstractEndpointWriter {
 
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+    public static final String APPLICATION_JSON_HEADER = "application/json";
+
     public static final String HTTP_URL_NAME = "_httpUrl";
     public static final String HTTP_URL_BUILDER_NAME = "_httpUrlBuilder";
     public static final String REQUEST_NAME = "_request";

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
@@ -113,6 +113,10 @@ public final class OnlyRequestEndpointWriter extends AbstractEndpointWriter {
                 .add(".url($L)\n", AbstractEndpointWriter.HTTP_URL_NAME)
                 .add(".method($S, $L)\n", httpEndpoint.getMethod().toString(), AbstractEndpointWriter.REQUEST_BODY_NAME)
                 .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
+                .add(
+                        ".addHeader($S, $S)\n",
+                        AbstractEndpointWriter.CONTENT_TYPE_HEADER,
+                        AbstractEndpointWriter.APPLICATION_JSON_HEADER)
                 .add(".build();\n")
                 .unindent()
                 .build();

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -195,7 +195,11 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 .indent()
                 .add(".url($L)\n", AbstractEndpointWriter.HTTP_URL_NAME)
                 .add(".method($S, $L)\n", httpEndpoint.getMethod().toString(), AbstractEndpointWriter.REQUEST_BODY_NAME)
-                .add(".headers($T.of($L.$N()));\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
+                .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
+                .add(
+                        ".addHeader($S, $S);\n",
+                        AbstractEndpointWriter.CONTENT_TYPE_HEADER,
+                        AbstractEndpointWriter.APPLICATION_JSON_HEADER)
                 .unindent();
         for (EnrichedObjectProperty header : generatedWrappedRequest.headerParams()) {
             if (typeNameIsOptional(header.poetTypeName())) {


### PR DESCRIPTION
Okhttp requires us manually sending the `Content-Type` header with `application/json`