### PR TITLE
fix: default to non forward compatible enums

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -1848,94 +1848,25 @@ public final class PostNotFoundErrorBody {
 basic[src/main/java/com/fern/basic/resources/blog/types/PostType.java]=[
 package com.fern.basic.resources.blog.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Locale;
 
-public final class PostType {
-  public static final PostType LONG = new PostType(Value.LONG, "LONG");
+public enum PostType {
+  LONG("LONG"),
 
-  public static final PostType SHORT = new PostType(Value.SHORT, "SHORT");
+  SHORT("SHORT"),
 
-  public static final PostType MEDIUM = new PostType(Value.MEDIUM, "med.med");
+  MEDIUM("med.med");
 
-  private final Value value;
+  private final String value;
 
-  private final String string;
-
-  PostType(Value value, String string) {
+  PostType(String value) {
     this.value = value;
-    this.string = string;
   }
 
-  public Value getEnumValue() {
-    return value;
-  }
-
-  @Override
   @JsonValue
+  @Override
   public String toString() {
-    return this.string;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return (this == other)
-        || (other instanceof PostType && this.string.equals(((PostType) other).string));
-  }
-
-  @Override
-  public int hashCode() {
-    return this.string.hashCode();
-  }
-
-  public <T> T visit(Visitor<T> visitor) {
-    switch (value) {
-      case LONG:
-        return visitor.visitLong();
-      case SHORT:
-        return visitor.visitShort();
-      case MEDIUM:
-        return visitor.visitMedium();
-      case UNKNOWN:
-      default:
-        return visitor.visitUnknown(string);
-    }
-  }
-
-  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-  public static PostType valueOf(String value) {
-    String upperCasedValue = value.toUpperCase(Locale.ROOT);
-    switch (upperCasedValue) {
-      case "LONG":
-        return LONG;
-      case "SHORT":
-        return SHORT;
-      case "med.med":
-        return MEDIUM;
-      default:
-        return new PostType(Value.UNKNOWN, upperCasedValue);
-    }
-  }
-
-  public enum Value {
-    LONG,
-
-    SHORT,
-
-    MEDIUM,
-
-    UNKNOWN
-  }
-
-  public interface Visitor<T> {
-    T visitLong();
-
-    T visitShort();
-
-    T visitMedium();
-
-    T visitUnknown(String unknownType);
+    return this.value;
   }
 }
 
@@ -2805,94 +2736,25 @@ public final class Device {
 basic[src/main/java/com/fern/basic/resources/raven/device/types/Platform.java]=[
 package com.fern.basic.resources.raven.device.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Locale;
 
-public final class Platform {
-  public static final Platform WEB = new Platform(Value.WEB, "web");
+public enum Platform {
+  ANDROID("android"),
 
-  public static final Platform IOS = new Platform(Value.IOS, "ios");
+  WEB("web"),
 
-  public static final Platform ANDROID = new Platform(Value.ANDROID, "android");
+  IOS("ios");
 
-  private final Value value;
+  private final String value;
 
-  private final String string;
-
-  Platform(Value value, String string) {
+  Platform(String value) {
     this.value = value;
-    this.string = string;
   }
 
-  public Value getEnumValue() {
-    return value;
-  }
-
-  @Override
   @JsonValue
+  @Override
   public String toString() {
-    return this.string;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return (this == other)
-        || (other instanceof Platform && this.string.equals(((Platform) other).string));
-  }
-
-  @Override
-  public int hashCode() {
-    return this.string.hashCode();
-  }
-
-  public <T> T visit(Visitor<T> visitor) {
-    switch (value) {
-      case WEB:
-        return visitor.visitWeb();
-      case IOS:
-        return visitor.visitIos();
-      case ANDROID:
-        return visitor.visitAndroid();
-      case UNKNOWN:
-      default:
-        return visitor.visitUnknown(string);
-    }
-  }
-
-  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-  public static Platform valueOf(String value) {
-    String upperCasedValue = value.toUpperCase(Locale.ROOT);
-    switch (upperCasedValue) {
-      case "web":
-        return WEB;
-      case "ios":
-        return IOS;
-      case "android":
-        return ANDROID;
-      default:
-        return new Platform(Value.UNKNOWN, upperCasedValue);
-    }
-  }
-
-  public enum Value {
-    ANDROID,
-
-    WEB,
-
-    IOS,
-
-    UNKNOWN
-  }
-
-  public interface Visitor<T> {
-    T visitAndroid();
-
-    T visitWeb();
-
-    T visitIos();
-
-    T visitUnknown(String unknownType);
+    return this.value;
   }
 }
 
@@ -7057,154 +6919,37 @@ public final class CreateUserRequest {
 basic[src/main/java/com/fern/basic/resources/raven/user/types/Channel.java]=[
 package com.fern.basic.resources.raven.user.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Locale;
 
-public final class Channel {
-  public static final Channel SMS = new Channel(Value.SMS, "SMS");
+public enum Channel {
+  VOICE("VOICE"),
 
-  public static final Channel IN_APP = new Channel(Value.IN_APP, "IN_APP");
+  PUSH("PUSH"),
 
-  public static final Channel TELEGRAM = new Channel(Value.TELEGRAM, "TELEGRAM");
+  SMS("SMS"),
 
-  public static final Channel PUSH = new Channel(Value.PUSH, "PUSH");
+  EMAIL("EMAIL"),
 
-  public static final Channel WHATSAPP = new Channel(Value.WHATSAPP, "WHATSAPP");
+  WHATSAPP("WHATSAPP"),
 
-  public static final Channel SLACK = new Channel(Value.SLACK, "SLACK");
+  WEBHOOK("WEBHOOK"),
 
-  public static final Channel EMAIL = new Channel(Value.EMAIL, "EMAIL");
+  SLACK("SLACK"),
 
-  public static final Channel WEBHOOK = new Channel(Value.WEBHOOK, "WEBHOOK");
+  IN_APP("IN_APP"),
 
-  public static final Channel VOICE = new Channel(Value.VOICE, "VOICE");
+  TELEGRAM("TELEGRAM");
 
-  private final Value value;
+  private final String value;
 
-  private final String string;
-
-  Channel(Value value, String string) {
+  Channel(String value) {
     this.value = value;
-    this.string = string;
   }
 
-  public Value getEnumValue() {
-    return value;
-  }
-
-  @Override
   @JsonValue
+  @Override
   public String toString() {
-    return this.string;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return (this == other)
-        || (other instanceof Channel && this.string.equals(((Channel) other).string));
-  }
-
-  @Override
-  public int hashCode() {
-    return this.string.hashCode();
-  }
-
-  public <T> T visit(Visitor<T> visitor) {
-    switch (value) {
-      case SMS:
-        return visitor.visitSms();
-      case IN_APP:
-        return visitor.visitInApp();
-      case TELEGRAM:
-        return visitor.visitTelegram();
-      case PUSH:
-        return visitor.visitPush();
-      case WHATSAPP:
-        return visitor.visitWhatsapp();
-      case SLACK:
-        return visitor.visitSlack();
-      case EMAIL:
-        return visitor.visitEmail();
-      case WEBHOOK:
-        return visitor.visitWebhook();
-      case VOICE:
-        return visitor.visitVoice();
-      case UNKNOWN:
-      default:
-        return visitor.visitUnknown(string);
-    }
-  }
-
-  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-  public static Channel valueOf(String value) {
-    String upperCasedValue = value.toUpperCase(Locale.ROOT);
-    switch (upperCasedValue) {
-      case "SMS":
-        return SMS;
-      case "IN_APP":
-        return IN_APP;
-      case "TELEGRAM":
-        return TELEGRAM;
-      case "PUSH":
-        return PUSH;
-      case "WHATSAPP":
-        return WHATSAPP;
-      case "SLACK":
-        return SLACK;
-      case "EMAIL":
-        return EMAIL;
-      case "WEBHOOK":
-        return WEBHOOK;
-      case "VOICE":
-        return VOICE;
-      default:
-        return new Channel(Value.UNKNOWN, upperCasedValue);
-    }
-  }
-
-  public enum Value {
-    VOICE,
-
-    PUSH,
-
-    SMS,
-
-    EMAIL,
-
-    WHATSAPP,
-
-    WEBHOOK,
-
-    SLACK,
-
-    IN_APP,
-
-    TELEGRAM,
-
-    UNKNOWN
-  }
-
-  public interface Visitor<T> {
-    T visitVoice();
-
-    T visitPush();
-
-    T visitSms();
-
-    T visitEmail();
-
-    T visitWhatsapp();
-
-    T visitWebhook();
-
-    T visitSlack();
-
-    T visitInApp();
-
-    T visitTelegram();
-
-    T visitUnknown(String unknownType);
+    return this.value;
   }
 }
 

--- a/generator-utils/src/main/java/com/fern/java/CustomConfig.java
+++ b/generator-utils/src/main/java/com/fern/java/CustomConfig.java
@@ -38,6 +38,12 @@ public interface CustomConfig {
         return false;
     }
 
+    @Value.Default
+    @JsonProperty("enable-forward-compatible-enums")
+    default Boolean enableForwardCompatibleEnum() {
+        return false;
+    }
+
     static ImmutableCustomConfig.Builder builder() {
         return ImmutableCustomConfig.builder();
     }

--- a/generator-utils/src/main/java/com/fern/java/generators/EnumGenerator.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/EnumGenerator.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2022 Birch Solutions Inc. All rights reserved.
+ * (c) Copyright 2023 Birch Solutions Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,45 +18,21 @@ package com.fern.java.generators;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fern.ir.v12.model.types.EnumTypeDeclaration;
-import com.fern.ir.v12.model.types.EnumValue;
 import com.fern.java.AbstractGeneratorContext;
-import com.fern.java.FernJavaAnnotations;
-import com.fern.java.VisitorFactory;
-import com.fern.java.VisitorFactory.GeneratedVisitor;
 import com.fern.java.output.GeneratedJavaFile;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 
 public final class EnumGenerator extends AbstractFileGenerator {
-
-    private static final String VALUE_TYPE_NAME = "Value";
-    private static final String VALUE_FIELD_NAME = "value";
-
-    private static final String STRING_FIELD_NAME = "string";
-
-    private static final String UNKNOWN_ENUM_CONSTANT = "UNKNOWN";
-
-    private static final String GET_ENUM_VALUE_METHOD_NAME = "getEnumValue";
-    private static final String TO_STRING_METHOD_NAME = "toString";
-    private static final String EQUALS_METHOD_NAME = "equals";
-    private static final String HASHCODE_METHOD_NAME = "hashCode";
-    private static final String VISIT_METHOD_NAME = "visit";
-    private static final String VALUE_OF_METHOD_NAME = "valueOf";
+    private static final FieldSpec VALUE_FIELD = FieldSpec.builder(String.class, "value")
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .build();
 
     private final EnumTypeDeclaration enumTypeDeclaration;
-    private final ClassName valueFieldClassName;
 
     public EnumGenerator(
             ClassName className,
@@ -64,211 +40,44 @@ public final class EnumGenerator extends AbstractFileGenerator {
             EnumTypeDeclaration enumTypeDeclaration) {
         super(className, generatorContext);
         this.enumTypeDeclaration = enumTypeDeclaration;
-        this.valueFieldClassName = this.className.nestedClass(VALUE_TYPE_NAME);
     }
 
     @Override
     public GeneratedJavaFile generateFile() {
-        Map<EnumValue, FieldSpec> enumConstants = getConstants();
-        VisitorFactory.GeneratedVisitor<EnumValue> generatedVisitor = getVisitor();
-        TypeSpec enumTypeSpec = TypeSpec.classBuilder(className)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addFields(enumConstants.values())
-                .addFields(getPrivateMembers())
-                .addMethod(getConstructor())
-                .addMethod(getEnumValueMethod())
-                .addMethod(getToStringMethod())
-                .addMethod(getEqualsMethod())
-                .addMethod(getHashCodeMethod())
-                .addMethod(getVisitMethod(generatedVisitor))
-                .addMethod(getValueOfMethod(enumConstants))
-                .addType(getNestedValueEnum())
-                .addType(generatedVisitor.typeSpec())
-                .build();
-        JavaFile enumFile =
-                JavaFile.builder(className.packageName(), enumTypeSpec).build();
-        return GeneratedJavaFile.builder()
-                .className(className)
-                .javaFile(enumFile)
-                .build();
-    }
+        if (generatorContext.getCustomConfig().enableForwardCompatibleEnum()) {
+            ForwardCompatibleEnumGenerator forwardCompatibleEnumGenerator =
+                    new ForwardCompatibleEnumGenerator(className, generatorContext, enumTypeDeclaration);
+            return forwardCompatibleEnumGenerator.generateFile();
+        } else {
+            TypeSpec.Builder enumTypeSpecBuilder = TypeSpec.enumBuilder(className);
+            enumTypeDeclaration.getValues().forEach(enumValue -> {
+                enumTypeSpecBuilder.addEnumConstant(
+                        enumValue.getName().getName().getScreamingSnakeCase().getSafeName(),
+                        TypeSpec.anonymousClassBuilder("$S", enumValue.getName().getWireValue())
+                                .build());
+            });
+            enumTypeSpecBuilder
+                    .addModifiers(Modifier.PUBLIC)
+                    .addField(VALUE_FIELD)
+                    .addMethod(MethodSpec.constructorBuilder()
+                            .addParameter(VALUE_FIELD.type, VALUE_FIELD.name)
+                            .addStatement("this.$L = $L", VALUE_FIELD.name, VALUE_FIELD.name)
+                            .build())
+                    .addMethod(MethodSpec.methodBuilder("toString")
+                            .addModifiers(Modifier.PUBLIC)
+                            .addAnnotation(JsonValue.class)
+                            .addAnnotation(Override.class)
+                            .returns(String.class)
+                            .addStatement("return this.$L", VALUE_FIELD.name)
+                            .build())
+                    .build();
 
-    private Map<EnumValue, FieldSpec> getConstants() {
-        // Generate public static final constant for each enum value
-        return enumTypeDeclaration.getValues().stream()
-                .collect(Collectors.toMap(Function.identity(), enumValue -> FieldSpec.builder(
-                                className,
-                                enumValue
-                                        .getName()
-                                        .getName()
-                                        .getScreamingSnakeCase()
-                                        .getSafeName(),
-                                Modifier.PUBLIC,
-                                Modifier.STATIC,
-                                Modifier.FINAL)
-                        .initializer(
-                                "new $T($T.$L, $S)",
-                                className,
-                                valueFieldClassName,
-                                enumValue
-                                        .getName()
-                                        .getName()
-                                        .getScreamingSnakeCase()
-                                        .getSafeName(),
-                                enumValue.getName().getWireValue())
-                        .build()));
-    }
-
-    private List<FieldSpec> getPrivateMembers() {
-        List<FieldSpec> privateMembers = new ArrayList<>();
-        // Add private Value Field
-        FieldSpec valueField = FieldSpec.builder(
-                        valueFieldClassName, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
-                .build();
-        privateMembers.add(valueField);
-        // Add private String Field
-        FieldSpec stringField = FieldSpec.builder(String.class, STRING_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
-                .build();
-        privateMembers.add(stringField);
-        return privateMembers;
-    }
-
-    private MethodSpec getConstructor() {
-        return MethodSpec.constructorBuilder()
-                .addParameter(valueFieldClassName, VALUE_FIELD_NAME)
-                .addParameter(String.class, STRING_FIELD_NAME)
-                .addStatement("this.value = value")
-                .addStatement("this.string = string")
-                .build();
-    }
-
-    private MethodSpec getEnumValueMethod() {
-        return MethodSpec.methodBuilder(GET_ENUM_VALUE_METHOD_NAME)
-                .addModifiers(Modifier.PUBLIC)
-                .addCode("return value;")
-                .returns(valueFieldClassName)
-                .build();
-    }
-
-    private MethodSpec getToStringMethod() {
-        return MethodSpec.methodBuilder(TO_STRING_METHOD_NAME)
-                .addAnnotation(Override.class)
-                .addAnnotation(JsonValue.class)
-                .addModifiers(Modifier.PUBLIC)
-                .addCode("return this.string;")
-                .returns(ClassName.get(String.class))
-                .build();
-    }
-
-    private MethodSpec getEqualsMethod() {
-        return MethodSpec.methodBuilder(EQUALS_METHOD_NAME)
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ClassName.get(Object.class), "other")
-                .addCode(CodeBlock.builder()
-                        .add(
-                                "return (this == other) \n"
-                                        + "  || (other instanceof $T && this.string.equals((($T) other).string));",
-                                className,
-                                className)
-                        .build())
-                .returns(boolean.class)
-                .build();
-    }
-
-    private MethodSpec getHashCodeMethod() {
-        return MethodSpec.methodBuilder(HASHCODE_METHOD_NAME)
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC)
-                .addCode("return this.string.hashCode();")
-                .returns(int.class)
-                .build();
-    }
-
-    private MethodSpec getVisitMethod(GeneratedVisitor<EnumValue> generatedVisitor) {
-        CodeBlock.Builder acceptMethodImplementation = CodeBlock.builder().beginControlFlow("switch (value)");
-        generatedVisitor.visitMethodsByKey().forEach((enumValue, visitMethod) -> {
-            acceptMethodImplementation
-                    .add(
-                            "case $L:\n",
-                            enumValue
-                                    .getName()
-                                    .getName()
-                                    .getScreamingSnakeCase()
-                                    .getSafeName())
-                    .indent()
-                    .addStatement("return visitor.$L()", visitMethod.name)
-                    .unindent();
-        });
-        CodeBlock acceptCodeBlock = acceptMethodImplementation
-                .add("case UNKNOWN:\n")
-                .add("default:\n")
-                .indent()
-                .addStatement("return visitor.visitUnknown(string)")
-                .unindent()
-                .endControlFlow()
-                .build();
-        return MethodSpec.methodBuilder(VISIT_METHOD_NAME)
-                .addModifiers(Modifier.PUBLIC)
-                .addTypeVariable(VisitorFactory.VISITOR_RETURN_TYPE)
-                .addParameter(VisitorFactory.getVisitorTypeName(className), "visitor")
-                .addCode(acceptCodeBlock)
-                .returns(VisitorFactory.VISITOR_RETURN_TYPE)
-                .build();
-    }
-
-    private MethodSpec getValueOfMethod(Map<EnumValue, FieldSpec> constants) {
-        CodeBlock.Builder valueOfCodeBlockBuilder = CodeBlock.builder()
-                .addStatement("String upperCasedValue = value.toUpperCase($T.ROOT)", Locale.class)
-                .beginControlFlow("switch (upperCasedValue)");
-        constants.forEach((enumValue, constantField) -> {
-            valueOfCodeBlockBuilder
-                    .add("case $S:\n", enumValue.getName().getWireValue())
-                    .indent()
-                    .addStatement("return $L", constantField.name)
-                    .unindent();
-        });
-        CodeBlock valueOfCodeBlock = valueOfCodeBlockBuilder
-                .add("default:\n")
-                .indent()
-                .addStatement("return new $T(Value.UNKNOWN, upperCasedValue)", className)
-                .unindent()
-                .endControlFlow()
-                .build();
-        return MethodSpec.methodBuilder(VALUE_OF_METHOD_NAME)
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addAnnotation(FernJavaAnnotations.jacksonDelegatingCreator())
-                .addCode(valueOfCodeBlock)
-                .returns(className)
-                .addParameter(ParameterSpec.builder(ClassName.get(String.class), "value")
-                        .build())
-                .build();
-    }
-
-    private TypeSpec getNestedValueEnum() {
-        TypeSpec.Builder nestedValueEnumBuilder =
-                TypeSpec.enumBuilder(VALUE_TYPE_NAME).addModifiers(Modifier.PUBLIC);
-        enumTypeDeclaration
-                .getValues()
-                .forEach(enumValue -> nestedValueEnumBuilder.addEnumConstant(
-                        enumValue.getName().getName().getScreamingSnakeCase().getSafeName()));
-        nestedValueEnumBuilder.addEnumConstant(UNKNOWN_ENUM_CONSTANT);
-        return nestedValueEnumBuilder.build();
-    }
-
-    private GeneratedVisitor<EnumValue> getVisitor() {
-        List<VisitorFactory.VisitMethodArgs<EnumValue>> visitMethodArgs = enumTypeDeclaration.getValues().stream()
-                .map(enumValue -> {
-                    return VisitorFactory.VisitMethodArgs.<EnumValue>builder()
-                            .key(enumValue)
-                            .pascalCaseName(enumValue
-                                    .getName()
-                                    .getName()
-                                    .getPascalCase()
-                                    .getSafeName())
-                            .build();
-                })
-                .collect(Collectors.toList());
-        return VisitorFactory.buildVisitorInterface(visitMethodArgs);
+            JavaFile enumFile = JavaFile.builder(className.packageName(), enumTypeSpecBuilder.build())
+                    .build();
+            return GeneratedJavaFile.builder()
+                    .className(className)
+                    .javaFile(enumFile)
+                    .build();
+        }
     }
 }

--- a/generator-utils/src/main/java/com/fern/java/generators/ForwardCompatibleEnumGenerator.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/ForwardCompatibleEnumGenerator.java
@@ -1,0 +1,274 @@
+/*
+ * (c) Copyright 2022 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.generators;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fern.ir.v12.model.types.EnumTypeDeclaration;
+import com.fern.ir.v12.model.types.EnumValue;
+import com.fern.java.AbstractGeneratorContext;
+import com.fern.java.FernJavaAnnotations;
+import com.fern.java.VisitorFactory;
+import com.fern.java.VisitorFactory.GeneratedVisitor;
+import com.fern.java.output.GeneratedJavaFile;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.lang.model.element.Modifier;
+
+public final class ForwardCompatibleEnumGenerator extends AbstractFileGenerator {
+
+    private static final String VALUE_TYPE_NAME = "Value";
+    private static final String VALUE_FIELD_NAME = "value";
+
+    private static final String STRING_FIELD_NAME = "string";
+
+    private static final String UNKNOWN_ENUM_CONSTANT = "UNKNOWN";
+
+    private static final String GET_ENUM_VALUE_METHOD_NAME = "getEnumValue";
+    private static final String TO_STRING_METHOD_NAME = "toString";
+    private static final String EQUALS_METHOD_NAME = "equals";
+    private static final String HASHCODE_METHOD_NAME = "hashCode";
+    private static final String VISIT_METHOD_NAME = "visit";
+    private static final String VALUE_OF_METHOD_NAME = "valueOf";
+
+    private final EnumTypeDeclaration enumTypeDeclaration;
+    private final ClassName valueFieldClassName;
+
+    public ForwardCompatibleEnumGenerator(
+            ClassName className,
+            AbstractGeneratorContext<?> generatorContext,
+            EnumTypeDeclaration enumTypeDeclaration) {
+        super(className, generatorContext);
+        this.enumTypeDeclaration = enumTypeDeclaration;
+        this.valueFieldClassName = this.className.nestedClass(VALUE_TYPE_NAME);
+    }
+
+    @Override
+    public GeneratedJavaFile generateFile() {
+        Map<EnumValue, FieldSpec> enumConstants = getConstants();
+        VisitorFactory.GeneratedVisitor<EnumValue> generatedVisitor = getVisitor();
+        TypeSpec enumTypeSpec = TypeSpec.classBuilder(className)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addFields(enumConstants.values())
+                .addFields(getPrivateMembers())
+                .addMethod(getConstructor())
+                .addMethod(getEnumValueMethod())
+                .addMethod(getToStringMethod())
+                .addMethod(getEqualsMethod())
+                .addMethod(getHashCodeMethod())
+                .addMethod(getVisitMethod(generatedVisitor))
+                .addMethod(getValueOfMethod(enumConstants))
+                .addType(getNestedValueEnum())
+                .addType(generatedVisitor.typeSpec())
+                .build();
+        JavaFile enumFile =
+                JavaFile.builder(className.packageName(), enumTypeSpec).build();
+        return GeneratedJavaFile.builder()
+                .className(className)
+                .javaFile(enumFile)
+                .build();
+    }
+
+    private Map<EnumValue, FieldSpec> getConstants() {
+        // Generate public static final constant for each enum value
+        return enumTypeDeclaration.getValues().stream()
+                .collect(Collectors.toMap(Function.identity(), enumValue -> FieldSpec.builder(
+                                className,
+                                enumValue
+                                        .getName()
+                                        .getName()
+                                        .getScreamingSnakeCase()
+                                        .getSafeName(),
+                                Modifier.PUBLIC,
+                                Modifier.STATIC,
+                                Modifier.FINAL)
+                        .initializer(
+                                "new $T($T.$L, $S)",
+                                className,
+                                valueFieldClassName,
+                                enumValue
+                                        .getName()
+                                        .getName()
+                                        .getScreamingSnakeCase()
+                                        .getSafeName(),
+                                enumValue.getName().getWireValue())
+                        .build()));
+    }
+
+    private List<FieldSpec> getPrivateMembers() {
+        List<FieldSpec> privateMembers = new ArrayList<>();
+        // Add private Value Field
+        FieldSpec valueField = FieldSpec.builder(
+                        valueFieldClassName, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
+                .build();
+        privateMembers.add(valueField);
+        // Add private String Field
+        FieldSpec stringField = FieldSpec.builder(String.class, STRING_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
+                .build();
+        privateMembers.add(stringField);
+        return privateMembers;
+    }
+
+    private MethodSpec getConstructor() {
+        return MethodSpec.constructorBuilder()
+                .addParameter(valueFieldClassName, VALUE_FIELD_NAME)
+                .addParameter(String.class, STRING_FIELD_NAME)
+                .addStatement("this.value = value")
+                .addStatement("this.string = string")
+                .build();
+    }
+
+    private MethodSpec getEnumValueMethod() {
+        return MethodSpec.methodBuilder(GET_ENUM_VALUE_METHOD_NAME)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode("return value;")
+                .returns(valueFieldClassName)
+                .build();
+    }
+
+    private MethodSpec getToStringMethod() {
+        return MethodSpec.methodBuilder(TO_STRING_METHOD_NAME)
+                .addAnnotation(Override.class)
+                .addAnnotation(JsonValue.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode("return this.string;")
+                .returns(ClassName.get(String.class))
+                .build();
+    }
+
+    private MethodSpec getEqualsMethod() {
+        return MethodSpec.methodBuilder(EQUALS_METHOD_NAME)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(ClassName.get(Object.class), "other")
+                .addCode(CodeBlock.builder()
+                        .add(
+                                "return (this == other) \n"
+                                        + "  || (other instanceof $T && this.string.equals((($T) other).string));",
+                                className,
+                                className)
+                        .build())
+                .returns(boolean.class)
+                .build();
+    }
+
+    private MethodSpec getHashCodeMethod() {
+        return MethodSpec.methodBuilder(HASHCODE_METHOD_NAME)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode("return this.string.hashCode();")
+                .returns(int.class)
+                .build();
+    }
+
+    private MethodSpec getVisitMethod(GeneratedVisitor<EnumValue> generatedVisitor) {
+        CodeBlock.Builder acceptMethodImplementation = CodeBlock.builder().beginControlFlow("switch (value)");
+        generatedVisitor.visitMethodsByKey().forEach((enumValue, visitMethod) -> {
+            acceptMethodImplementation
+                    .add(
+                            "case $L:\n",
+                            enumValue
+                                    .getName()
+                                    .getName()
+                                    .getScreamingSnakeCase()
+                                    .getSafeName())
+                    .indent()
+                    .addStatement("return visitor.$L()", visitMethod.name)
+                    .unindent();
+        });
+        CodeBlock acceptCodeBlock = acceptMethodImplementation
+                .add("case UNKNOWN:\n")
+                .add("default:\n")
+                .indent()
+                .addStatement("return visitor.visitUnknown(string)")
+                .unindent()
+                .endControlFlow()
+                .build();
+        return MethodSpec.methodBuilder(VISIT_METHOD_NAME)
+                .addModifiers(Modifier.PUBLIC)
+                .addTypeVariable(VisitorFactory.VISITOR_RETURN_TYPE)
+                .addParameter(VisitorFactory.getVisitorTypeName(className), "visitor")
+                .addCode(acceptCodeBlock)
+                .returns(VisitorFactory.VISITOR_RETURN_TYPE)
+                .build();
+    }
+
+    private MethodSpec getValueOfMethod(Map<EnumValue, FieldSpec> constants) {
+        CodeBlock.Builder valueOfCodeBlockBuilder = CodeBlock.builder()
+                .addStatement("String upperCasedValue = value.toUpperCase($T.ROOT)", Locale.class)
+                .beginControlFlow("switch (upperCasedValue)");
+        constants.forEach((enumValue, constantField) -> {
+            valueOfCodeBlockBuilder
+                    .add("case $S:\n", enumValue.getName().getWireValue())
+                    .indent()
+                    .addStatement("return $L", constantField.name)
+                    .unindent();
+        });
+        CodeBlock valueOfCodeBlock = valueOfCodeBlockBuilder
+                .add("default:\n")
+                .indent()
+                .addStatement("return new $T(Value.UNKNOWN, upperCasedValue)", className)
+                .unindent()
+                .endControlFlow()
+                .build();
+        return MethodSpec.methodBuilder(VALUE_OF_METHOD_NAME)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addAnnotation(FernJavaAnnotations.jacksonDelegatingCreator())
+                .addCode(valueOfCodeBlock)
+                .returns(className)
+                .addParameter(ParameterSpec.builder(ClassName.get(String.class), "value")
+                        .build())
+                .build();
+    }
+
+    private TypeSpec getNestedValueEnum() {
+        TypeSpec.Builder nestedValueEnumBuilder =
+                TypeSpec.enumBuilder(VALUE_TYPE_NAME).addModifiers(Modifier.PUBLIC);
+        enumTypeDeclaration
+                .getValues()
+                .forEach(enumValue -> nestedValueEnumBuilder.addEnumConstant(
+                        enumValue.getName().getName().getScreamingSnakeCase().getSafeName()));
+        nestedValueEnumBuilder.addEnumConstant(UNKNOWN_ENUM_CONSTANT);
+        return nestedValueEnumBuilder.build();
+    }
+
+    private GeneratedVisitor<EnumValue> getVisitor() {
+        List<VisitorFactory.VisitMethodArgs<EnumValue>> visitMethodArgs = enumTypeDeclaration.getValues().stream()
+                .map(enumValue -> {
+                    return VisitorFactory.VisitMethodArgs.<EnumValue>builder()
+                            .key(enumValue)
+                            .pascalCaseName(enumValue
+                                    .getName()
+                                    .getName()
+                                    .getPascalCase()
+                                    .getSafeName())
+                            .build();
+                })
+                .collect(Collectors.toList());
+        return VisitorFactory.buildVisitorInterface(visitMethodArgs);
+    }
+}

--- a/generator-utils/src/main/java/com/fern/java/generators/SingleTypeGenerator.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/SingleTypeGenerator.java
@@ -66,8 +66,8 @@ public final class SingleTypeGenerator implements Type.Visitor<Optional<Generate
 
     @Override
     public Optional<GeneratedJavaFile> visitEnum(EnumTypeDeclaration value) {
-        EnumGenerator enumGenerator = new EnumGenerator(className, generatorContext, value);
-        return Optional.of(enumGenerator.generateFile());
+        EnumGenerator forwardCompatibleEnumGenerator = new EnumGenerator(className, generatorContext, value);
+        return Optional.of(forwardCompatibleEnumGenerator.generateFile());
     }
 
     @Override

--- a/model-generator/src/eteTest/java/com/fern/java/model/__snapshots__/ModelGeneratorEteTest.snap
+++ b/model-generator/src/eteTest/java/com/fern/java/model/__snapshots__/ModelGeneratorEteTest.snap
@@ -971,94 +971,25 @@ public final class PostNotFoundErrorBody {
 basic[src/main/java/com/fern/basic/model/blog/PostType.java]=[
 package com.fern.basic.model.blog;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Locale;
 
-public final class PostType {
-  public static final PostType LONG = new PostType(Value.LONG, "LONG");
+public enum PostType {
+  LONG("LONG"),
 
-  public static final PostType SHORT = new PostType(Value.SHORT, "SHORT");
+  SHORT("SHORT"),
 
-  public static final PostType MEDIUM = new PostType(Value.MEDIUM, "med.med");
+  MEDIUM("med.med");
 
-  private final Value value;
+  private final String value;
 
-  private final String string;
-
-  PostType(Value value, String string) {
+  PostType(String value) {
     this.value = value;
-    this.string = string;
   }
 
-  public Value getEnumValue() {
-    return value;
-  }
-
-  @Override
   @JsonValue
+  @Override
   public String toString() {
-    return this.string;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return (this == other)
-        || (other instanceof PostType && this.string.equals(((PostType) other).string));
-  }
-
-  @Override
-  public int hashCode() {
-    return this.string.hashCode();
-  }
-
-  public <T> T visit(Visitor<T> visitor) {
-    switch (value) {
-      case LONG:
-        return visitor.visitLong();
-      case SHORT:
-        return visitor.visitShort();
-      case MEDIUM:
-        return visitor.visitMedium();
-      case UNKNOWN:
-      default:
-        return visitor.visitUnknown(string);
-    }
-  }
-
-  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-  public static PostType valueOf(String value) {
-    String upperCasedValue = value.toUpperCase(Locale.ROOT);
-    switch (upperCasedValue) {
-      case "LONG":
-        return LONG;
-      case "SHORT":
-        return SHORT;
-      case "med.med":
-        return MEDIUM;
-      default:
-        return new PostType(Value.UNKNOWN, upperCasedValue);
-    }
-  }
-
-  public enum Value {
-    LONG,
-
-    SHORT,
-
-    MEDIUM,
-
-    UNKNOWN
-  }
-
-  public interface Visitor<T> {
-    T visitLong();
-
-    T visitShort();
-
-    T visitMedium();
-
-    T visitUnknown(String unknownType);
+    return this.value;
   }
 }
 

--- a/spring-server-generator/src/eteTest/java/com/fern/java/spring/__snapshots__/SpringGeneratorEteTest.snap
+++ b/spring-server-generator/src/eteTest/java/com/fern/java/spring/__snapshots__/SpringGeneratorEteTest.snap
@@ -1146,99 +1146,27 @@ public final class PostNotFoundErrorBody {
 basic[resources/blog/types/PostType.java]=[
 package com.fern.resources.blog.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Locale;
 
-public final class PostType {
-  public static final PostType LONG = new PostType(Value.LONG, "LONG");
+public enum PostType {
+  LONG("LONG"),
 
-  public static final PostType SHORT = new PostType(Value.SHORT, "SHORT");
+  SHORT("SHORT"),
 
-  public static final PostType MEDIUM = new PostType(Value.MEDIUM, "med.med");
+  MEDIUM("med.med");
 
-  private final Value value;
+  private final String value;
 
-  private final String string;
-
-  PostType(Value value, String string) {
+  PostType(String value) {
     this.value = value;
-    this.string = string;
   }
 
-  public Value getEnumValue() {
-    return value;
-  }
-
-  @Override
   @JsonValue
+  @Override
   public String toString() {
-    return this.string;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return (this == other) 
-      || (other instanceof PostType && this.string.equals(((PostType) other).string));
-  }
-
-  @Override
-  public int hashCode() {
-    return this.string.hashCode();
-  }
-
-  public <T> T visit(Visitor<T> visitor) {
-    switch (value) {
-      case LONG:
-        return visitor.visitLong();
-      case SHORT:
-        return visitor.visitShort();
-      case MEDIUM:
-        return visitor.visitMedium();
-      case UNKNOWN:
-      default:
-        return visitor.visitUnknown(string);
-    }
-  }
-
-  @JsonCreator(
-      mode = JsonCreator.Mode.DELEGATING
-  )
-  public static PostType valueOf(String value) {
-    String upperCasedValue = value.toUpperCase(Locale.ROOT);
-    switch (upperCasedValue) {
-      case "LONG":
-        return LONG;
-      case "SHORT":
-        return SHORT;
-      case "med.med":
-        return MEDIUM;
-      default:
-        return new PostType(Value.UNKNOWN, upperCasedValue);
-    }
-  }
-
-  public enum Value {
-    LONG,
-
-    SHORT,
-
-    MEDIUM,
-
-    UNKNOWN
-  }
-
-  public interface Visitor<T> {
-    T visitLong();
-
-    T visitShort();
-
-    T visitMedium();
-
-    T visitUnknown(String unknownType);
+    return this.value;
   }
 }
 


### PR DESCRIPTION
introduce a custom config `enable-forward-compatible-enums` which is defaulted to false. Now, by default generated enums won't have visitors and won't have an `UNKNOWN` field. 