### PR TITLE
feature: client options supports taking in header suppliers

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -418,6 +418,7 @@ package com.fern.basic.core;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import okhttp3.OkHttpClient;
 
 public final class ClientOptions {
@@ -425,12 +426,18 @@ public final class ClientOptions {
 
   private final Map<String, String> headers;
 
+  private final Map<String, Supplier<String>> headerSuppliers;
+
   private final OkHttpClient httpClient;
 
   private ClientOptions(
-      Environment environment, Map<String, String> headers, OkHttpClient httpClient) {
+      Environment environment,
+      Map<String, String> headers,
+      Map<String, Supplier<String>> headerSuppliers,
+      OkHttpClient httpClient) {
     this.environment = environment;
     this.headers = headers;
+    this.headerSuppliers = headerSuppliers;
     this.httpClient = httpClient;
   }
 
@@ -439,7 +446,12 @@ public final class ClientOptions {
   }
 
   public Map<String, String> headers() {
-    return this.headers;
+    Map<String, String> values = new HashMap<>(this.headers);
+    headerSuppliers.forEach(
+        (key, supplier) -> {
+          values.put(key, supplier.get());
+        });
+    return values;
   }
 
   public OkHttpClient httpClient() {
@@ -455,6 +467,8 @@ public final class ClientOptions {
 
     private final Map<String, String> headers = new HashMap<>();
 
+    private final Map<String, Supplier<String>> headerSuppliers = new HashMap<>();
+
     public Builder environment(Environment environment) {
       this.environment = environment;
       return this;
@@ -465,8 +479,13 @@ public final class ClientOptions {
       return this;
     }
 
+    public Builder addHeader(String key, Supplier<String> value) {
+      this.headerSuppliers.put(key, value);
+      return this;
+    }
+
     public ClientOptions build() {
-      return new ClientOptions(environment, headers, new OkHttpClient());
+      return new ClientOptions(environment, headers, headerSuppliers, new OkHttpClient());
     }
   }
 }


### PR DESCRIPTION
The header suppliers are invoked every time  `headers()` are retrieved from `ClientOptions`. This ensures the header values are never stale.