### PR TITLE
feature: generate client builder outside of client wrappers

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -283,7 +283,6 @@ exec "$JAVACMD" "$@"
 basic[src/main/java/com/fern/basic/FernFernClient.java]=[
 package com.fern.basic;
 
-import com.fern.basic.core.Environment;
 import com.fern.basic.resources.auth.AuthClient;
 import com.fern.basic.resources.blog.BlogClient;
 import com.fern.basic.resources.dummyservice.DummyServiceClient;
@@ -298,20 +297,48 @@ public interface FernFernClient {
 
   RavenClient raven();
 
-  static Builder builder() {
-    return new FernFernClientImpl.Builder();
+  static FernFernClientBuilder builder() {
+    return new FernFernClientBuilder();
+  }
+}
+
+]
+
+
+basic[src/main/java/com/fern/basic/FernFernClientBuilder.java]=[
+package com.fern.basic;
+
+import com.fern.basic.core.ClientOptions;
+import com.fern.basic.core.Environment;
+
+public final class FernFernClientBuilder {
+  ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder();
+
+  Environment environment = Environment.PROD;
+
+  public FernFernClientBuilder token(String token) {
+    this.clientOptionsBuilder.addHeader("Authorization", "Bearer " + token);
+    return this;
   }
 
-  interface Builder {
-    Builder token(String token);
+  public FernFernClientBuilder apiVersion(String apiVersion) {
+    this.clientOptionsBuilder.addHeader("API-VERSION", apiVersion);
+    return this;
+  }
 
-    Builder apiVersion(String apiVersion);
+  public FernFernClientBuilder environment(Environment environment) {
+    this.environment = environment;
+    return this;
+  }
 
-    Builder environment(Environment environment);
+  public FernFernClientBuilder url(String url) {
+    this.environment = Environment.custom(url);
+    return this;
+  }
 
-    Builder url(String url);
-
-    FernFernClient build();
+  public FernFernClient build() {
+    clientOptionsBuilder.environment(this.environment);
+    return new FernFernClientImpl(clientOptionsBuilder.build());
   }
 }
 
@@ -322,7 +349,6 @@ basic[src/main/java/com/fern/basic/FernFernClientImpl.java]=[
 package com.fern.basic;
 
 import com.fern.basic.core.ClientOptions;
-import com.fern.basic.core.Environment;
 import com.fern.basic.core.Suppliers;
 import com.fern.basic.resources.auth.AuthClient;
 import com.fern.basic.resources.auth.AuthClientImpl;
@@ -371,42 +397,6 @@ public final class FernFernClientImpl implements FernFernClient {
   @Override
   public RavenClient raven() {
     return this.ravenClient.get();
-  }
-
-  public static final class Builder implements FernFernClient.Builder {
-    ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder();
-
-    Environment environment = Environment.PROD;
-
-    @Override
-    public FernFernClient.Builder token(String token) {
-      this.clientOptionsBuilder.addHeader("Authorization", "Bearer " + token);
-      return this;
-    }
-
-    @Override
-    public FernFernClient.Builder apiVersion(String apiVersion) {
-      this.clientOptionsBuilder.addHeader("API-VERSION", apiVersion);
-      return this;
-    }
-
-    @Override
-    public FernFernClient.Builder environment(Environment environment) {
-      this.environment = environment;
-      return this;
-    }
-
-    @Override
-    public FernFernClient.Builder url(String url) {
-      this.environment = Environment.custom(url);
-      return this;
-    }
-
-    @Override
-    public FernFernClient build() {
-      clientOptionsBuilder.environment(this.environment);
-      return new FernFernClientImpl(clientOptionsBuilder.build());
-    }
   }
 }
 

--- a/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
+++ b/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
@@ -82,7 +82,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
                 AbstractPoetClassNameFactory.getPackagePrefixWithOrgAndApiName(ir, generatorConfig.getOrganization()));
         ClientGeneratorContext context =
                 new ClientGeneratorContext(ir, generatorConfig, customConfig, clientPoetClassNameFactory);
-        GeneratedClient generatedClientWrapper = generateClient(context, ir);
+        GeneratedRootClient generatedClientWrapper = generateClient(context, ir);
         SampleAppGenerator sampleAppGenerator = new SampleAppGenerator(context, generatedClientWrapper);
         sampleAppGenerator.generateFiles().forEach(this::addGeneratedFile);
         subprojects.add(SampleAppGenerator.SAMPLE_APP_DIRECTORY);
@@ -102,7 +102,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
         generateClient(context, ir);
     }
 
-    public GeneratedClient generateClient(ClientGeneratorContext context, IntermediateRepresentation ir) {
+    public GeneratedRootClient generateClient(ClientGeneratorContext context, IntermediateRepresentation ir) {
 
         // core
         ObjectMappersGenerator objectMappersGenerator = new ObjectMappersGenerator(context);
@@ -156,9 +156,10 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
                 generatedSuppliersFile,
                 generatedEnvironmentsClass,
                 generatedTypes.getInterfaces());
-        GeneratedClient generatedRootClient = rootClientGenerator.generateFile();
+        GeneratedRootClient generatedRootClient = rootClientGenerator.generateFile();
         this.addGeneratedFile(generatedRootClient);
         this.addGeneratedFile(generatedRootClient.clientImpl());
+        this.addGeneratedFile(generatedRootClient.builderClass());
         generatedRootClient.wrappedRequests().forEach(this::addGeneratedFile);
 
         return generatedRootClient;

--- a/client-generator/src/main/java/com/fern/java/client/GeneratedRootClient.java
+++ b/client-generator/src/main/java/com/fern/java/client/GeneratedRootClient.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2023 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.client;
+
+import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import com.fern.java.output.AbstractGeneratedJavaFile;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@StagedBuilderImmutablesStyle
+public abstract class GeneratedRootClient extends AbstractGeneratedJavaFile {
+
+    public abstract AbstractGeneratedJavaFile clientImpl();
+
+    public abstract AbstractGeneratedJavaFile builderClass();
+
+    public abstract List<GeneratedWrappedRequest> wrappedRequests();
+
+    public static ImmutableGeneratedRootClient.ClassNameBuildStage builder() {
+        return ImmutableGeneratedRootClient.builder();
+    }
+}

--- a/client-generator/src/main/java/com/fern/java/client/generators/SampleAppGenerator.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/SampleAppGenerator.java
@@ -17,7 +17,7 @@
 package com.fern.java.client.generators;
 
 import com.fern.java.AbstractGeneratorContext;
-import com.fern.java.client.GeneratedClient;
+import com.fern.java.client.GeneratedRootClient;
 import com.fern.java.generators.AbstractFilesGenerator;
 import com.fern.java.output.GeneratedBuildGradle;
 import com.fern.java.output.GeneratedFile;
@@ -35,11 +35,12 @@ import javax.lang.model.element.Modifier;
 
 public final class SampleAppGenerator extends AbstractFilesGenerator {
 
-    private final GeneratedClient generatedClientWrapper;
+    private final GeneratedRootClient generatedClientWrapper;
 
     public static final String SAMPLE_APP_DIRECTORY = "sample-app";
 
-    public SampleAppGenerator(AbstractGeneratorContext<?> generatorContext, GeneratedClient generatedClientWrapper) {
+    public SampleAppGenerator(
+            AbstractGeneratorContext<?> generatorContext, GeneratedRootClient generatedClientWrapper) {
         super(generatorContext);
         this.generatedClientWrapper = generatedClientWrapper;
     }


### PR DESCRIPTION
By generating the client builder outside of the wrapper client as a nested class, it allows sdk users to easily configure it. For example, you can add logic in the builder to do oauth2 with clientId/clientSecret. 