### PR TITLE
:herb: only add wrapped request fields if present

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -2611,9 +2611,15 @@ public class EventClient {
         Map<String, Object> _requestBodyProperties = new HashMap<>();
         _requestBodyProperties.put("event", request.getEvent());
         _requestBodyProperties.put("data", request.getData());
-        _requestBodyProperties.put("user", request.getUser());
-        _requestBodyProperties.put("scheduleAt", request.getScheduleAt());
-        _requestBodyProperties.put("override", request.getOverride());
+        if (request.getUser().isPresent()) {
+            _requestBodyProperties.put("user", request.getUser());
+        }
+        if (request.getScheduleAt().isPresent()) {
+            _requestBodyProperties.put("scheduleAt", request.getScheduleAt());
+        }
+        if (request.getOverride().isPresent()) {
+            _requestBodyProperties.put("override", request.getOverride());
+        }
         RequestBody _requestBody;
         try {
             _requestBody = RequestBody.create(
@@ -6164,9 +6170,15 @@ public class UserClient {
                 .build();
         Map<String, Object> _requestBodyProperties = new HashMap<>();
         _requestBodyProperties.put("user_id", request.getUserId());
-        _requestBodyProperties.put("mobile", request.getMobile());
-        _requestBodyProperties.put("email", request.getEmail());
-        _requestBodyProperties.put("whats_app", request.getWhatsApp());
+        if (request.getMobile().isPresent()) {
+            _requestBodyProperties.put("mobile", request.getMobile());
+        }
+        if (request.getEmail().isPresent()) {
+            _requestBodyProperties.put("email", request.getEmail());
+        }
+        if (request.getWhatsApp().isPresent()) {
+            _requestBodyProperties.put("whats_app", request.getWhatsApp());
+        }
         RequestBody _requestBody;
         try {
             _requestBody = RequestBody.create(

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -122,11 +122,23 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 InlinedRequestBodyGetters inlinedRequestBodyGetter = ((InlinedRequestBodyGetters)
                         generatedWrappedRequest.requestBodyGetter().get());
                 for (EnrichedObjectProperty bodyProperty : inlinedRequestBodyGetter.properties()) {
-                    requestInitializerBuilder.addStatement(
-                            "$L.put($S, $L)",
-                            REQUEST_BODY_PROPERTIES_NAME,
-                            bodyProperty.wireKey().get(),
-                            requestParameterName + "." + bodyProperty.getterProperty().name + "()");
+                    if (typeNameIsOptional(bodyProperty.poetTypeName())) {
+                        requestInitializerBuilder
+                                .beginControlFlow(
+                                        "if ($L.$N().isPresent())", requestParameterName, bodyProperty.getterProperty())
+                                .addStatement(
+                                        "$L.put($S, $L)",
+                                        REQUEST_BODY_PROPERTIES_NAME,
+                                        bodyProperty.wireKey().get(),
+                                        requestParameterName + "." + bodyProperty.getterProperty().name + "()")
+                                .endControlFlow();
+                    } else {
+                        requestInitializerBuilder.addStatement(
+                                "$L.put($S, $L)",
+                                REQUEST_BODY_PROPERTIES_NAME,
+                                bodyProperty.wireKey().get(),
+                                requestParameterName + "." + bodyProperty.getterProperty().name + "()");
+                    }
                 }
                 requestBodyArgument = REQUEST_BODY_PROPERTIES_NAME;
             }


### PR DESCRIPTION
Only populate request body properties if they are present.