### PR TITLE
fix: endpoints are overloaded and use request options

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -629,7 +629,7 @@ public class AuthClient {
         this.clientOptions = clientOptions;
     }
 
-    void getAuth() {
+    public void getAuth() {
         getAuth();
     }
 
@@ -807,7 +807,7 @@ public class BlogClient {
         this.clientOptions = clientOptions;
     }
 
-    void createPost(CreatePostRequest request) {
+    public void createPost(CreatePostRequest request) {
         createPost(request);
     }
 
@@ -850,7 +850,7 @@ public class BlogClient {
         }
     }
 
-    BlogPost getPost(String postId, GetPostRequest request) {
+    public BlogPost getPost(String postId, GetPostRequest request) {
         return getPost(postId, request);
     }
 
@@ -879,7 +879,7 @@ public class BlogClient {
         }
     }
 
-    List<BlogPost> getAll() {
+    public List<BlogPost> getAll() {
         return getAll();
     }
 
@@ -906,7 +906,7 @@ public class BlogClient {
         }
     }
 
-    String useVariable() {
+    public String useVariable() {
         return useVariable();
     }
 
@@ -2005,7 +2005,7 @@ public class DummyServiceClient {
         this.clientOptions = clientOptions;
     }
 
-    void getDummy(String request) {
+    public void getDummy(String request) {
         getDummy(request);
     }
 
@@ -2038,7 +2038,7 @@ public class DummyServiceClient {
         }
     }
 
-    void health() {
+    public void health() {
         health();
     }
 
@@ -2089,7 +2089,7 @@ public class FileDownloadClient {
         this.clientOptions = clientOptions;
     }
 
-    InputStream getFileDownload(String request) {
+    public InputStream getFileDownload(String request) {
         return getFileDownload(request);
     }
 
@@ -2189,7 +2189,7 @@ public class DeviceClient {
         this.clientOptions = clientOptions;
     }
 
-    Device add(String appId, String userId, Device request) {
+    public Device add(String appId, String userId, Device request) {
         return add(appId, userId, request);
     }
 
@@ -2226,7 +2226,7 @@ public class DeviceClient {
         }
     }
 
-    Device update(String appId, String userId, String deviceId, Device request) {
+    public Device update(String appId, String userId, String deviceId, Device request) {
         return update(appId, userId, deviceId, request);
     }
 
@@ -2264,7 +2264,7 @@ public class DeviceClient {
         }
     }
 
-    void delete(String appId, String userId, String deviceId) {
+    public void delete(String appId, String userId, String deviceId) {
         delete(appId, userId, deviceId);
     }
 
@@ -2294,7 +2294,7 @@ public class DeviceClient {
         }
     }
 
-    Device getDevice(String appId, String userId, String deviceId) {
+    public Device getDevice(String appId, String userId, String deviceId) {
         return getDevice(appId, userId, deviceId);
     }
 
@@ -2788,7 +2788,7 @@ public class EventClient {
         this.clientOptions = clientOptions;
     }
 
-    SendEventResponse send(String appId, SendEventRequest request) {
+    public SendEventResponse send(String appId, SendEventRequest request) {
         return send(appId, request);
     }
 
@@ -2840,7 +2840,7 @@ public class EventClient {
         }
     }
 
-    SendEventResponse sendBulk(String appId, BulkSendEventRequest request) {
+    public SendEventResponse sendBulk(String appId, BulkSendEventRequest request) {
         return sendBulk(appId, request);
     }
 
@@ -6403,7 +6403,7 @@ public class UserClient {
         this.clientOptions = clientOptions;
     }
 
-    RavenUser createOrUpdate(String appId, CreateUserRequest request) {
+    public RavenUser createOrUpdate(String appId, CreateUserRequest request) {
         return createOrUpdate(appId, request);
     }
 
@@ -6450,7 +6450,7 @@ public class UserClient {
         }
     }
 
-    RavenUser get(String appId, String userId) {
+    public RavenUser get(String appId, String userId) {
         return get(appId, userId);
     }
 

--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -630,7 +630,7 @@ public class AuthClient {
     }
 
     public void getAuth() {
-        getAuth();
+        getAuth(null);
     }
 
     public void getAuth(RequestOptions requestOptions) {
@@ -808,7 +808,7 @@ public class BlogClient {
     }
 
     public void createPost(CreatePostRequest request) {
-        createPost(request);
+        createPost(request, null);
     }
 
     public void createPost(CreatePostRequest request, RequestOptions requestOptions) {
@@ -851,7 +851,7 @@ public class BlogClient {
     }
 
     public BlogPost getPost(String postId, GetPostRequest request) {
-        return getPost(postId, request);
+        return getPost(postId, request, null);
     }
 
     public BlogPost getPost(String postId, GetPostRequest request, RequestOptions requestOptions) {
@@ -880,7 +880,7 @@ public class BlogClient {
     }
 
     public List<BlogPost> getAll() {
-        return getAll();
+        return getAll(null);
     }
 
     public List<BlogPost> getAll(RequestOptions requestOptions) {
@@ -907,7 +907,7 @@ public class BlogClient {
     }
 
     public String useVariable() {
-        return useVariable();
+        return useVariable(null);
     }
 
     public String useVariable(RequestOptions requestOptions) {
@@ -2006,7 +2006,7 @@ public class DummyServiceClient {
     }
 
     public void getDummy(String request) {
-        getDummy(request);
+        getDummy(request, null);
     }
 
     public void getDummy(String request, RequestOptions requestOptions) {
@@ -2039,7 +2039,7 @@ public class DummyServiceClient {
     }
 
     public void health() {
-        health();
+        health(null);
     }
 
     public void health(RequestOptions requestOptions) {
@@ -2090,7 +2090,7 @@ public class FileDownloadClient {
     }
 
     public InputStream getFileDownload(String request) {
-        return getFileDownload(request);
+        return getFileDownload(request, null);
     }
 
     public InputStream getFileDownload(String request, RequestOptions requestOptions) {
@@ -2190,7 +2190,7 @@ public class DeviceClient {
     }
 
     public Device add(String appId, String userId, Device request) {
-        return add(appId, userId, request);
+        return add(appId, userId, request, null);
     }
 
     public Device add(String appId, String userId, Device request, RequestOptions requestOptions) {
@@ -2227,7 +2227,7 @@ public class DeviceClient {
     }
 
     public Device update(String appId, String userId, String deviceId, Device request) {
-        return update(appId, userId, deviceId, request);
+        return update(appId, userId, deviceId, request, null);
     }
 
     public Device update(String appId, String userId, String deviceId, Device request, RequestOptions requestOptions) {
@@ -2265,7 +2265,7 @@ public class DeviceClient {
     }
 
     public void delete(String appId, String userId, String deviceId) {
-        delete(appId, userId, deviceId);
+        delete(appId, userId, deviceId, null);
     }
 
     public void delete(String appId, String userId, String deviceId, RequestOptions requestOptions) {
@@ -2295,7 +2295,7 @@ public class DeviceClient {
     }
 
     public Device getDevice(String appId, String userId, String deviceId) {
-        return getDevice(appId, userId, deviceId);
+        return getDevice(appId, userId, deviceId, null);
     }
 
     public Device getDevice(String appId, String userId, String deviceId, RequestOptions requestOptions) {
@@ -2789,7 +2789,7 @@ public class EventClient {
     }
 
     public SendEventResponse send(String appId, SendEventRequest request) {
-        return send(appId, request);
+        return send(appId, request, null);
     }
 
     public SendEventResponse send(String appId, SendEventRequest request, RequestOptions requestOptions) {
@@ -2841,7 +2841,7 @@ public class EventClient {
     }
 
     public SendEventResponse sendBulk(String appId, BulkSendEventRequest request) {
-        return sendBulk(appId, request);
+        return sendBulk(appId, request, null);
     }
 
     public SendEventResponse sendBulk(String appId, BulkSendEventRequest request, RequestOptions requestOptions) {
@@ -6404,7 +6404,7 @@ public class UserClient {
     }
 
     public RavenUser createOrUpdate(String appId, CreateUserRequest request) {
-        return createOrUpdate(appId, request);
+        return createOrUpdate(appId, request, null);
     }
 
     public RavenUser createOrUpdate(String appId, CreateUserRequest request, RequestOptions requestOptions) {
@@ -6451,7 +6451,7 @@ public class UserClient {
     }
 
     public RavenUser get(String appId, String userId) {
-        return get(appId, userId);
+        return get(appId, userId, null);
     }
 
     public RavenUser get(String appId, String userId, RequestOptions requestOptions) {

--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -423,11 +423,14 @@ public final class ClientOptions {
         return this.environment;
     }
 
-    public Map<String, String> headers() {
+    public Map<String, String> headers(RequestOptions requestOptions) {
         Map<String, String> values = new HashMap<>(this.headers);
         headerSuppliers.forEach((key, supplier) -> {
             values.put(key, supplier.get());
         });
+        if (requestOptions != null) {
+            values.putAll(requestOptions.getHeaders());
+        }
         return values;
     }
 
@@ -613,6 +616,7 @@ basic[src/main/java/com/fern/basic/resources/auth/AuthClient.java]=[
 package com.fern.basic.resources.auth;
 
 import com.fern.basic.core.ClientOptions;
+import com.fern.basic.core.RequestOptions;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
@@ -625,7 +629,11 @@ public class AuthClient {
         this.clientOptions = clientOptions;
     }
 
-    public void getAuth() {
+    void getAuth() {
+        getAuth();
+    }
+
+    public void getAuth(RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("auth")
@@ -633,7 +641,7 @@ public class AuthClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("GET", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
         try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -778,6 +786,7 @@ package com.fern.basic.resources.blog;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import com.fern.basic.resources.blog.requests.CreatePostRequest;
 import com.fern.basic.resources.blog.requests.GetPostRequest;
 import com.fern.basic.resources.blog.types.BlogPost;
@@ -798,7 +807,11 @@ public class BlogClient {
         this.clientOptions = clientOptions;
     }
 
-    public void createPost(CreatePostRequest request) {
+    void createPost(CreatePostRequest request) {
+        createPost(request);
+    }
+
+    public void createPost(CreatePostRequest request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("posts")
@@ -823,7 +836,7 @@ public class BlogClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         Request _request = _requestBuilder.build();
         try {
@@ -837,7 +850,11 @@ public class BlogClient {
         }
     }
 
-    public BlogPost getPost(String postId, GetPostRequest request) {
+    BlogPost getPost(String postId, GetPostRequest request) {
+        return getPost(postId, request);
+    }
+
+    public BlogPost getPost(String postId, GetPostRequest request, RequestOptions requestOptions) {
         HttpUrl.Builder _httpUrl = HttpUrl.parse(
                         this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -848,7 +865,7 @@ public class BlogClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl.build())
                 .method("GET", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         Request _request = _requestBuilder.build();
         try {
@@ -862,7 +879,11 @@ public class BlogClient {
         }
     }
 
-    public List<BlogPost> getAll() {
+    List<BlogPost> getAll() {
+        return getAll();
+    }
+
+    public List<BlogPost> getAll(RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("posts")
@@ -870,7 +891,7 @@ public class BlogClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("GET", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -885,7 +906,11 @@ public class BlogClient {
         }
     }
 
-    public String useVariable() {
+    String useVariable() {
+        return useVariable();
+    }
+
+    public String useVariable(RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("posts")
@@ -895,7 +920,7 @@ public class BlogClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -1965,6 +1990,7 @@ package com.fern.basic.resources.dummyservice;
 
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -1979,7 +2005,11 @@ public class DummyServiceClient {
         this.clientOptions = clientOptions;
     }
 
-    public void getDummy(String request) {
+    void getDummy(String request) {
+        getDummy(request);
+    }
+
+    public void getDummy(String request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("dummy")
@@ -1994,7 +2024,7 @@ public class DummyServiceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -2008,7 +2038,11 @@ public class DummyServiceClient {
         }
     }
 
-    public void health() {
+    void health() {
+        health();
+    }
+
+    public void health(RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("dummy")
@@ -2017,7 +2051,7 @@ public class DummyServiceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("GET", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
         try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2039,6 +2073,7 @@ package com.fern.basic.resources.filedownload;
 
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import java.io.InputStream;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -2054,7 +2089,11 @@ public class FileDownloadClient {
         this.clientOptions = clientOptions;
     }
 
-    public InputStream getFileDownload(String request) {
+    InputStream getFileDownload(String request) {
+        return getFileDownload(request);
+    }
+
+    public InputStream getFileDownload(String request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("file-dowonload")
@@ -2069,7 +2108,7 @@ public class FileDownloadClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -2134,6 +2173,7 @@ package com.fern.basic.resources.raven.device;
 
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import com.fern.basic.resources.raven.device.types.Device;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -2149,7 +2189,11 @@ public class DeviceClient {
         this.clientOptions = clientOptions;
     }
 
-    public Device add(String appId, String userId, Device request) {
+    Device add(String appId, String userId, Device request) {
+        return add(appId, userId, request);
+    }
+
+    public Device add(String appId, String userId, Device request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2168,7 +2212,7 @@ public class DeviceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -2182,7 +2226,11 @@ public class DeviceClient {
         }
     }
 
-    public Device update(String appId, String userId, String deviceId, Device request) {
+    Device update(String appId, String userId, String deviceId, Device request) {
+        return update(appId, userId, deviceId, request);
+    }
+
+    public Device update(String appId, String userId, String deviceId, Device request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2202,7 +2250,7 @@ public class DeviceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("PUT", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -2216,7 +2264,11 @@ public class DeviceClient {
         }
     }
 
-    public void delete(String appId, String userId, String deviceId) {
+    void delete(String appId, String userId, String deviceId) {
+        delete(appId, userId, deviceId);
+    }
+
+    public void delete(String appId, String userId, String deviceId, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2229,7 +2281,7 @@ public class DeviceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("DELETE", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
         try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();
@@ -2242,7 +2294,11 @@ public class DeviceClient {
         }
     }
 
-    public Device getDevice(String appId, String userId, String deviceId) {
+    Device getDevice(String appId, String userId, String deviceId) {
+        return getDevice(appId, userId, deviceId);
+    }
+
+    public Device getDevice(String appId, String userId, String deviceId, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2255,7 +2311,7 @@ public class DeviceClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("GET", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {
@@ -2712,6 +2768,7 @@ package com.fern.basic.resources.raven.event;
 
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import com.fern.basic.resources.raven.event.requests.BulkSendEventRequest;
 import com.fern.basic.resources.raven.event.requests.SendEventRequest;
 import com.fern.basic.resources.raven.event.types.SendEventResponse;
@@ -2731,7 +2788,11 @@ public class EventClient {
         this.clientOptions = clientOptions;
     }
 
-    public SendEventResponse send(String appId, SendEventRequest request) {
+    SendEventResponse send(String appId, SendEventRequest request) {
+        return send(appId, request);
+    }
+
+    public SendEventResponse send(String appId, SendEventRequest request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2761,7 +2822,7 @@ public class EventClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         if (request.getIdempotencyKey().isPresent()) {
             _requestBuilder.addHeader(
@@ -2779,7 +2840,11 @@ public class EventClient {
         }
     }
 
-    public SendEventResponse sendBulk(String appId, BulkSendEventRequest request) {
+    SendEventResponse sendBulk(String appId, BulkSendEventRequest request) {
+        return sendBulk(appId, request);
+    }
+
+    public SendEventResponse sendBulk(String appId, BulkSendEventRequest request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -2800,7 +2865,7 @@ public class EventClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         if (request.getIdempotencyKey().isPresent()) {
             _requestBuilder.addHeader(
@@ -6319,6 +6384,7 @@ package com.fern.basic.resources.raven.user;
 
 import com.fern.basic.core.ClientOptions;
 import com.fern.basic.core.ObjectMappers;
+import com.fern.basic.core.RequestOptions;
 import com.fern.basic.resources.raven.user.requests.CreateUserRequest;
 import com.fern.basic.resources.raven.user.types.RavenUser;
 import java.util.HashMap;
@@ -6337,7 +6403,11 @@ public class UserClient {
         this.clientOptions = clientOptions;
     }
 
-    public RavenUser createOrUpdate(String appId, CreateUserRequest request) {
+    RavenUser createOrUpdate(String appId, CreateUserRequest request) {
+        return createOrUpdate(appId, request);
+    }
+
+    public RavenUser createOrUpdate(String appId, CreateUserRequest request, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -6366,7 +6436,7 @@ public class UserClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         Request _request = _requestBuilder.build();
         try {
@@ -6380,7 +6450,11 @@ public class UserClient {
         }
     }
 
-    public RavenUser get(String appId, String userId) {
+    RavenUser get(String appId, String userId) {
+        return get(appId, userId);
+    }
+
+    public RavenUser get(String appId, String userId, RequestOptions requestOptions) {
         HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v1/apps")
@@ -6391,7 +6465,7 @@ public class UserClient {
         Request _request = new Request.Builder()
                 .url(_httpUrl)
                 .method("GET", null)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
                 .build();
         try {

--- a/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
+++ b/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
@@ -113,17 +113,18 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
         GeneratedEnvironmentsClass generatedEnvironmentsClass = environmentGenerator.generateFile();
         this.addGeneratedFile(generatedEnvironmentsClass);
 
-        ClientOptionsGenerator clientOptionsGenerator = new ClientOptionsGenerator(context, generatedEnvironmentsClass);
+        RequestOptionsGenerator requestOptionsGenerator = new RequestOptionsGenerator(context);
+        GeneratedJavaFile generatedRequestOptions = requestOptionsGenerator.generateFile();
+        this.addGeneratedFile(generatedRequestOptions);
+
+        ClientOptionsGenerator clientOptionsGenerator =
+                new ClientOptionsGenerator(context, generatedEnvironmentsClass, generatedRequestOptions);
         GeneratedClientOptions generatedClientOptions = clientOptionsGenerator.generateFile();
         this.addGeneratedFile(generatedClientOptions);
 
         SuppliersGenerator suppliersGenerator = new SuppliersGenerator(context);
         GeneratedJavaFile generatedSuppliersFile = suppliersGenerator.generateFile();
         this.addGeneratedFile(generatedSuppliersFile);
-
-        RequestOptionsGenerator requestOptionsGenerator = new RequestOptionsGenerator(context);
-        GeneratedJavaFile generatedRequestOptions = requestOptionsGenerator.generateFile();
-        this.addGeneratedFile(generatedRequestOptions);
 
         // types
         TypesGenerator typesGenerator = new TypesGenerator(context, false);
@@ -144,6 +145,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
                     generatedClientOptions,
                     generatedSuppliersFile,
                     generatedEnvironmentsClass,
+                    generatedRequestOptions,
                     generatedTypes.getInterfaces());
             GeneratedClient generatedClient = httpServiceClientGenerator.generateFile();
             this.addGeneratedFile(generatedClient);
@@ -158,6 +160,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
                 generatedClientOptions,
                 generatedSuppliersFile,
                 generatedEnvironmentsClass,
+                generatedRequestOptions,
                 generatedTypes.getInterfaces());
         GeneratedRootClient generatedRootClient = rootClientGenerator.generateFile();
         this.addGeneratedFile(generatedRootClient);

--- a/client-generator/src/main/java/com/fern/java/client/generators/ClientGeneratorUtils.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/ClientGeneratorUtils.java
@@ -27,6 +27,7 @@ import com.fern.java.client.GeneratedClientOptions;
 import com.fern.java.client.GeneratedEnvironmentsClass;
 import com.fern.java.client.GeneratedWrappedRequest;
 import com.fern.java.client.generators.endpoint.HttpEndpointMethodSpecFactory;
+import com.fern.java.client.generators.endpoint.HttpEndpointMethodSpecs;
 import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedJavaInterface;
 import com.fern.java.output.GeneratedObjectMapper;
@@ -56,6 +57,7 @@ public final class ClientGeneratorUtils {
     private final GeneratedJavaFile generatedSuppliersFile;
     private final GeneratedEnvironmentsClass generatedEnvironmentsClass;
     private final List<GeneratedWrappedRequest> generatedWrappedRequests = new ArrayList<>();
+    private final GeneratedJavaFile requestOptionsFile;
 
     public ClientGeneratorUtils(
             ClassName clientImplName,
@@ -65,6 +67,7 @@ public final class ClientGeneratorUtils {
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
             Map<TypeId, GeneratedJavaInterface> allGeneratedInterfaces,
             GeneratedJavaFile generatedSuppliersFile,
+            GeneratedJavaFile requestOptionsFile,
             IPackage fernPackage) {
         this.generatorContext = clientGeneratorContext;
         this.clientOptionsField = FieldSpec.builder(generatedClientOptions.getClassName(), "clientOptions")
@@ -79,6 +82,7 @@ public final class ClientGeneratorUtils {
         this.generatedObjectMapper = generatedObjectMapper;
         this.generatedClientOptions = generatedClientOptions;
         this.generatedEnvironmentsClass = generatedEnvironmentsClass;
+        this.requestOptionsFile = requestOptionsFile;
     }
 
     public Result buildClients() {
@@ -101,9 +105,11 @@ public final class ClientGeneratorUtils {
                         generatedClientOptions,
                         clientOptionsField,
                         generatedEnvironmentsClass,
+                        requestOptionsFile,
                         allGeneratedInterfaces);
-                MethodSpec endpointMethodSpec = httpEndpointMethodSpecFactory.create();
-                implBuilder.addMethod(endpointMethodSpec.toBuilder().build());
+                HttpEndpointMethodSpecs httpEndpointMethodSpecs = httpEndpointMethodSpecFactory.create();
+                implBuilder.addMethod(httpEndpointMethodSpecs.getRequestOptionsMethodSpec());
+                implBuilder.addMethod(httpEndpointMethodSpecs.getNonRequestOptionsMethodSpec());
                 generatedWrappedRequests.addAll(httpEndpointMethodSpecFactory.getGeneratedWrappedRequests());
             }
         }

--- a/client-generator/src/main/java/com/fern/java/client/generators/RootClientGenerator.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/RootClientGenerator.java
@@ -53,6 +53,7 @@ public final class RootClientGenerator extends AbstractFileGenerator {
     private final GeneratedJavaFile generatedSuppliersFile;
     private final GeneratedEnvironmentsClass generatedEnvironmentsClass;
     private final ClassName builderName;
+    private final GeneratedJavaFile requestOptionsFile;
 
     public RootClientGenerator(
             AbstractGeneratorContext<?, ?> generatorContext,
@@ -61,6 +62,7 @@ public final class RootClientGenerator extends AbstractFileGenerator {
             GeneratedClientOptions generatedClientOptions,
             GeneratedJavaFile generatedSuppliersFile,
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
+            GeneratedJavaFile requestOptionsFile,
             Map<TypeId, GeneratedJavaInterface> allGeneratedInterfaces) {
         super(
                 generatorContext.getPoetClassNameFactory().getRootClassName(getRootClientName(generatorContext)),
@@ -72,6 +74,7 @@ public final class RootClientGenerator extends AbstractFileGenerator {
         this.generatedEnvironmentsClass = generatedEnvironmentsClass;
         this.allGeneratedInterfaces = allGeneratedInterfaces;
         this.builderName = ClassName.get(className.packageName(), className.simpleName() + "Builder");
+        this.requestOptionsFile = requestOptionsFile;
     }
 
     @Override
@@ -84,6 +87,7 @@ public final class RootClientGenerator extends AbstractFileGenerator {
                 generatedEnvironmentsClass,
                 allGeneratedInterfaces,
                 generatedSuppliersFile,
+                requestOptionsFile,
                 generatorContext.getIr().getRootPackage());
         Result result = clientGeneratorUtils.buildClients();
 
@@ -223,7 +227,7 @@ public final class RootClientGenerator extends AbstractFileGenerator {
                         generatorContext.getGeneratorConfig().getWorkspaceName());
     }
 
-    private class AuthSchemeHandler implements AuthScheme.Visitor<Void> {
+    private final class AuthSchemeHandler implements AuthScheme.Visitor<Void> {
 
         private final TypeSpec.Builder builder;
 

--- a/client-generator/src/main/java/com/fern/java/client/generators/SubpackageClientGenerator.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/SubpackageClientGenerator.java
@@ -39,6 +39,7 @@ public final class SubpackageClientGenerator extends AbstractFileGenerator {
     private final GeneratedJavaFile generatedSuppliersFile;
     private final GeneratedEnvironmentsClass generatedEnvironmentsClass;
     private final Subpackage subpackage;
+    private final GeneratedJavaFile requestOptionsFile;
 
     public SubpackageClientGenerator(
             Subpackage subpackage,
@@ -48,6 +49,7 @@ public final class SubpackageClientGenerator extends AbstractFileGenerator {
             GeneratedClientOptions generatedClientOptions,
             GeneratedJavaFile generatedSuppliersFile,
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
+            GeneratedJavaFile requestOptionsFile,
             Map<TypeId, GeneratedJavaInterface> allGeneratedInterfaces) {
         super(clientGeneratorContext.getPoetClassNameFactory().getClientClassName(subpackage), generatorContext);
         this.generatedObjectMapper = generatedObjectMapper;
@@ -56,6 +58,7 @@ public final class SubpackageClientGenerator extends AbstractFileGenerator {
         this.generatedSuppliersFile = generatedSuppliersFile;
         this.allGeneratedInterfaces = allGeneratedInterfaces;
         this.generatedEnvironmentsClass = generatedEnvironmentsClass;
+        this.requestOptionsFile = requestOptionsFile;
         this.subpackage = subpackage;
     }
 
@@ -69,6 +72,7 @@ public final class SubpackageClientGenerator extends AbstractFileGenerator {
                 generatedEnvironmentsClass,
                 allGeneratedInterfaces,
                 generatedSuppliersFile,
+                requestOptionsFile,
                 subpackage);
         Result result = clientGeneratorUtils.buildClients();
         return GeneratedClient.builder()

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -149,6 +149,7 @@ public abstract class AbstractEndpointWriter {
         String params =
                 pathParameters.stream().map(parameterSpec -> parameterSpec.name).collect(Collectors.joining(", "));
         MethodSpec endpointWithoutRequestOptions = MethodSpec.methodBuilder(endpointWithRequestOptions.name)
+                .addModifiers(Modifier.PUBLIC)
                 .addParameters(pathParameters)
                 .addStatement(
                         endpointWithRequestOptions.returnType.equals(TypeName.VOID)

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -32,6 +32,7 @@ import com.fern.java.client.GeneratedEnvironmentsClass.MultiUrlEnvironmentsClass
 import com.fern.java.client.GeneratedEnvironmentsClass.SingleUrlEnvironmentClass;
 import com.fern.java.client.generators.endpoint.HttpUrlBuilder.PathParamInfo;
 import com.fern.java.generators.object.EnrichedObjectProperty;
+import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -58,6 +59,7 @@ public abstract class AbstractEndpointWriter {
     public static final String REQUEST_BUILDER_NAME = "_requestBuilder";
     public static final String REQUEST_BODY_NAME = "_requestBody";
     public static final String RESPONSE_NAME = "_response";
+    public static final String REQUEST_OPTIONS_PARAMETER_NAME = "requestOptions";
     private final HttpService httpService;
     private final HttpEndpoint httpEndpoint;
     private final GeneratedClientOptions generatedClientOptions;
@@ -66,6 +68,7 @@ public abstract class AbstractEndpointWriter {
     private final MethodSpec.Builder endpointMethodBuilder;
     private final GeneratedObjectMapper generatedObjectMapper;
     private final GeneratedEnvironmentsClass generatedEnvironmentsClass;
+    private final GeneratedJavaFile requestOptionsFile;
 
     public AbstractEndpointWriter(
             HttpService httpService,
@@ -74,7 +77,8 @@ public abstract class AbstractEndpointWriter {
             ClientGeneratorContext clientGeneratorContext,
             FieldSpec clientOptionsField,
             GeneratedClientOptions generatedClientOptions,
-            GeneratedEnvironmentsClass generatedEnvironmentsClass) {
+            GeneratedEnvironmentsClass generatedEnvironmentsClass,
+            GeneratedJavaFile requestOptionsFile) {
         this.httpService = httpService;
         this.httpEndpoint = httpEndpoint;
         this.clientOptionsField = clientOptionsField;
@@ -85,19 +89,23 @@ public abstract class AbstractEndpointWriter {
         this.endpointMethodBuilder = MethodSpec.methodBuilder(
                         httpEndpoint.getName().get().getCamelCase().getSafeName())
                 .addModifiers(Modifier.PUBLIC);
+        this.requestOptionsFile = requestOptionsFile;
     }
 
-    public final MethodSpec generate() {
+    public final HttpEndpointMethodSpecs generate() {
         // Step 1: Add Path Params as parameters
         List<ParameterSpec> pathParameters = getPathParameters();
-        for (ParameterSpec pathParameter : pathParameters) {
-            endpointMethodBuilder.addParameter(pathParameter);
-        }
 
         // Step 2: Add additional parameters
-        endpointMethodBuilder.addParameters(additionalParameters());
+        pathParameters.addAll(additionalParameters());
 
-        // Step 3: Get http client initializer
+        // Step 3: Add path parameters
+        endpointMethodBuilder.addParameters(pathParameters);
+        endpointMethodBuilder.addParameter(
+                ParameterSpec.builder(requestOptionsFile.getClassName(), REQUEST_OPTIONS_PARAMETER_NAME)
+                        .build());
+
+        // Step 4: Get http client initializer
         HttpUrlBuilder httpUrlBuilder = new HttpUrlBuilder(
                 HTTP_URL_NAME,
                 sdkRequest()
@@ -120,7 +128,7 @@ public abstract class AbstractEndpointWriter {
         HttpUrlBuilder.GeneratedHttpUrl generatedHttpUrl = httpUrlBuilder.generateBuilder(getQueryParams());
         endpointMethodBuilder.addCode(generatedHttpUrl.initialization());
 
-        // Step 4: Get request initializer
+        // Step 5: Get request initializer
         boolean sendContentType = httpEndpoint.getRequestBody().isPresent()
                 || httpEndpoint.getResponse().isPresent();
         CodeBlock requestInitializer = getInitializeRequestCodeBlock(
@@ -132,10 +140,25 @@ public abstract class AbstractEndpointWriter {
                 sendContentType);
         endpointMethodBuilder.addCode(requestInitializer);
 
-        // Step 5: Make http request and handle responses
+        // Step 6: Make http request and handle responses
         CodeBlock responseParser = getResponseParserCodeBlock();
         endpointMethodBuilder.addCode(responseParser);
-        return endpointMethodBuilder.build();
+
+        MethodSpec endpointWithRequestOptions = endpointMethodBuilder.build();
+
+        String params =
+                pathParameters.stream().map(parameterSpec -> parameterSpec.name).collect(Collectors.joining(", "));
+        MethodSpec endpointWithoutRequestOptions = MethodSpec.methodBuilder(endpointWithRequestOptions.name)
+                .addParameters(pathParameters)
+                .addStatement(
+                        endpointWithRequestOptions.returnType.equals(TypeName.VOID)
+                                ? endpointWithRequestOptions.name + "(" + params + ")"
+                                : "return " + endpointWithRequestOptions.name + "(" + params + ")",
+                        endpointWithRequestOptions.name)
+                .returns(endpointWithRequestOptions.returnType)
+                .build();
+
+        return new HttpEndpointMethodSpecs(endpointWithRequestOptions, endpointWithoutRequestOptions);
     }
 
     public abstract Optional<SdkRequest> sdkRequest();

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -146,15 +146,17 @@ public abstract class AbstractEndpointWriter {
 
         MethodSpec endpointWithRequestOptions = endpointMethodBuilder.build();
 
-        String params =
-                pathParameters.stream().map(parameterSpec -> parameterSpec.name).collect(Collectors.joining(", "));
+        List<String> paramNames =
+                pathParameters.stream().map(parameterSpec -> parameterSpec.name).collect(Collectors.toList());
+        paramNames.add("null");
         MethodSpec endpointWithoutRequestOptions = MethodSpec.methodBuilder(endpointWithRequestOptions.name)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameters(pathParameters)
                 .addStatement(
                         endpointWithRequestOptions.returnType.equals(TypeName.VOID)
-                                ? endpointWithRequestOptions.name + "(" + params + ")"
-                                : "return " + endpointWithRequestOptions.name + "(" + params + ")",
+                                ? endpointWithRequestOptions.name + "(" + String.join(",", paramNames) + ")"
+                                : "return " + endpointWithRequestOptions.name + "(" + String.join(",", paramNames)
+                                        + ")",
                         endpointWithRequestOptions.name)
                 .returns(endpointWithRequestOptions.returnType)
                 .build();

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/HttpEndpointMethodSpecs.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/HttpEndpointMethodSpecs.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2023 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.client.generators.endpoint;
+
+import com.squareup.javapoet.MethodSpec;
+
+public final class HttpEndpointMethodSpecs {
+
+    private final MethodSpec nonRequestOptionsMethodSpec;
+    private final MethodSpec requestOptionsMethodSpec;
+
+    public HttpEndpointMethodSpecs(MethodSpec nonRequestOptionsMethodSpec, MethodSpec requestOptionsMethodSpec) {
+        this.nonRequestOptionsMethodSpec = nonRequestOptionsMethodSpec;
+        this.requestOptionsMethodSpec = requestOptionsMethodSpec;
+    }
+
+    public MethodSpec getNonRequestOptionsMethodSpec() {
+        return nonRequestOptionsMethodSpec;
+    }
+
+    public MethodSpec getRequestOptionsMethodSpec() {
+        return requestOptionsMethodSpec;
+    }
+}

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
@@ -23,6 +23,7 @@ import com.fern.java.client.ClientGeneratorContext;
 import com.fern.java.client.GeneratedClientOptions;
 import com.fern.java.client.GeneratedEnvironmentsClass;
 import com.fern.java.generators.object.EnrichedObjectProperty;
+import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -42,7 +43,8 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
             ClientGeneratorContext clientGeneratorContext,
             FieldSpec clientOptionsField,
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
-            GeneratedClientOptions generatedClientOptions) {
+            GeneratedClientOptions generatedClientOptions,
+            GeneratedJavaFile requestOptionsFile) {
         super(
                 httpService,
                 httpEndpoint,
@@ -50,7 +52,8 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
                 clientGeneratorContext,
                 clientOptionsField,
                 generatedClientOptions,
-                generatedEnvironmentsClass);
+                generatedEnvironmentsClass,
+                requestOptionsFile);
     }
 
     @Override
@@ -83,7 +86,12 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
                 .add(inlineableHttpUrl)
                 .add(")\n")
                 .add(".method($S, null)\n", httpEndpoint.getMethod().toString())
-                .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers());
+                .add(
+                        ".headers($T.of($L.$N($L)))\n",
+                        Headers.class,
+                        clientOptionsMember.name,
+                        clientOptions.headers(),
+                        REQUEST_OPTIONS_PARAMETER_NAME);
         if (sendContentType) {
             builder.add(
                     ".addHeader($S, $S)\n",

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/OnlyRequestEndpointWriter.java
@@ -24,6 +24,7 @@ import com.fern.java.client.ClientGeneratorContext;
 import com.fern.java.client.GeneratedClientOptions;
 import com.fern.java.client.GeneratedEnvironmentsClass;
 import com.fern.java.generators.object.EnrichedObjectProperty;
+import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -50,7 +51,8 @@ public final class OnlyRequestEndpointWriter extends AbstractEndpointWriter {
             GeneratedClientOptions generatedClientOptions,
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
             HttpRequestBodyReference httpRequestBodyReference,
-            SdkRequest sdkRequest) {
+            SdkRequest sdkRequest,
+            GeneratedJavaFile requestOptionsFile) {
         super(
                 httpService,
                 httpEndpoint,
@@ -58,7 +60,8 @@ public final class OnlyRequestEndpointWriter extends AbstractEndpointWriter {
                 clientGeneratorContext,
                 clientOptionsField,
                 generatedClientOptions,
-                generatedEnvironmentsClass);
+                generatedEnvironmentsClass,
+                requestOptionsFile);
         this.clientGeneratorContext = clientGeneratorContext;
         this.httpEndpoint = httpEndpoint;
         this.httpRequestBodyReference = httpRequestBodyReference;
@@ -115,7 +118,12 @@ public final class OnlyRequestEndpointWriter extends AbstractEndpointWriter {
                 .add(inlineableHttpUrl)
                 .add(")\n")
                 .add(".method($S, $L)\n", httpEndpoint.getMethod().toString(), AbstractEndpointWriter.REQUEST_BODY_NAME)
-                .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers());
+                .add(
+                        ".headers($T.of($L.$N($L)))\n",
+                        Headers.class,
+                        clientOptionsMember.name,
+                        clientOptions.headers(),
+                        REQUEST_OPTIONS_PARAMETER_NAME);
         if (sendContentType) {
             builder.add(
                     ".addHeader($S, $S)\n",

--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -26,6 +26,7 @@ import com.fern.java.client.GeneratedWrappedRequest;
 import com.fern.java.client.GeneratedWrappedRequest.InlinedRequestBodyGetters;
 import com.fern.java.client.GeneratedWrappedRequest.ReferencedRequestBodyGetter;
 import com.fern.java.generators.object.EnrichedObjectProperty;
+import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -61,7 +62,8 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
             ClientGeneratorContext clientGeneratorContext,
             SdkRequest sdkRequest,
             GeneratedEnvironmentsClass generatedEnvironmentsClass,
-            GeneratedWrappedRequest generatedWrappedRequest) {
+            GeneratedWrappedRequest generatedWrappedRequest,
+            GeneratedJavaFile requestOptionsFile) {
         super(
                 httpService,
                 httpEndpoint,
@@ -69,7 +71,8 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 clientGeneratorContext,
                 clientOptionsField,
                 generatedClientOptions,
-                generatedEnvironmentsClass);
+                generatedEnvironmentsClass,
+                requestOptionsFile);
         this.clientGeneratorContext = clientGeneratorContext;
         this.generatedWrappedRequest = generatedWrappedRequest;
         this.sdkRequest = sdkRequest;
@@ -178,14 +181,23 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                         AbstractEndpointWriter.REQUEST_BODY_NAME);
         if (sendContentType) {
             requestInitializerBuilder
-                    .add(".headers($T.of($L.$N()))\n", Headers.class, clientOptionsMember.name, clientOptions.headers())
+                    .add(
+                            ".headers($T.of($L.$N($L)))\n",
+                            Headers.class,
+                            clientOptionsMember.name,
+                            clientOptions.headers(),
+                            AbstractEndpointWriter.REQUEST_OPTIONS_PARAMETER_NAME)
                     .add(
                             ".addHeader($S, $S);\n",
                             AbstractEndpointWriter.CONTENT_TYPE_HEADER,
                             AbstractEndpointWriter.APPLICATION_JSON_HEADER);
         } else {
             requestInitializerBuilder.add(
-                    ".headers($T.of($L.$N()));\n", Headers.class, clientOptionsMember.name, clientOptions.headers());
+                    ".headers($T.of($L.$N($L)));\n",
+                    Headers.class,
+                    clientOptionsMember.name,
+                    clientOptions.headers(),
+                    AbstractEndpointWriter.REQUEST_OPTIONS_PARAMETER_NAME);
         }
         requestInitializerBuilder.unindent();
         for (EnrichedObjectProperty header : generatedWrappedRequest.headerParams()) {


### PR DESCRIPTION
Each endpoint is overloaded with request options so that the user can specify RequestOptions if they want to, but don't have to. 