### PR TITLE
fix: generated java sdk sends fern platform headers

### DIFF
--- a/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
+++ b/client-generator/src/eteTest/java/com/fern/java/client/cli/__snapshots__/ClientGeneratorEteTest.snap
@@ -421,7 +421,9 @@ public final class ClientOptions {
             OkHttpClient httpClient,
             String appName) {
         this.environment = environment;
-        this.headers = headers;
+        this.headers = new HashMap<>();
+        this.headers.putAll(headers);
+        this.headers.putAll(Map.of("X-Fern-Language", "JAVA"));
         this.headerSuppliers = headerSuppliers;
         this.httpClient = httpClient;
         this.appName = appName;


### PR DESCRIPTION
The generated java sdk will now send fern platform headers `X-Fern-SDK-Name`, `X-Fern-SDK-Version`, and `X-Fern-SDK-Language`. These headers will make it easy for users to track requests made through fern generated SDKs. 