### PR TITLE
fix: file upload should not be sent with `application/json` Content-Type

### DIFF
--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -183,7 +183,8 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                         ".method($S, $L)\n",
                         httpEndpoint.getMethod().toString(),
                         AbstractEndpointWriter.REQUEST_BODY_NAME);
-        if (sendContentType) {
+        if (sendContentType
+                && !(generatedWrappedRequest.requestBodyGetter().get() instanceof FileUploadRequestBodyGetters)) {
             requestBodyCodeBlock
                     .add(
                             ".headers($T.of($L.$N($L)))\n",

--- a/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
+++ b/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
@@ -32,14 +32,13 @@ public class ServiceClient {
                 .newBuilder()
                 .build();
         MultipartBody.Builder _multipartBody = new MultipartBody.Builder().setType(MultipartBody.FORM);
-        try {
         if (request.getMaybeString().isPresent()) {
             _multipartBody.addFormDataPart("maybeString", request.getMaybeString());
         }
         _multipartBody.addFormDataPart("integer", request.getInteger());
         _multipartBody.addFormDataPart("file", null, RequestBody.create(null, file));
-        if (maybeFile.isPresent()) {
-            _multipartBody.addFormDataPart("maybeFile", null, RequestBody.create(null, maybeFile.get()));
+        if (request.maybeFile().isPresent()) {
+            _multipartBody.addFormDataPart("maybeFile", null, RequestBody.create(null, maybeFile));
         }
         if (request.getMaybeInteger().isPresent()) {
             _multipartBody.addFormDataPart("maybeInteger", request.getMaybeInteger());
@@ -67,6 +66,7 @@ public class ServiceClient {
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
+        try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();
             if (_response.isSuccessful()) {
                 return;

--- a/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
+++ b/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
@@ -32,13 +32,14 @@ public class ServiceClient {
                 .newBuilder()
                 .build();
         MultipartBody.Builder _multipartBody = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        try {
         if (request.getMaybeString().isPresent()) {
             _multipartBody.addFormDataPart("maybeString", request.getMaybeString());
         }
         _multipartBody.addFormDataPart("integer", request.getInteger());
         _multipartBody.addFormDataPart("file", null, RequestBody.create(null, file));
-        if (request.maybeFile().isPresent()) {
-            _multipartBody.addFormDataPart("maybeFile", null, RequestBody.create(null, maybeFile));
+        if (maybeFile.isPresent()) {
+            _multipartBody.addFormDataPart("maybeFile", null, RequestBody.create(null, maybeFile.get()));
         }
         if (request.getMaybeInteger().isPresent()) {
             _multipartBody.addFormDataPart("maybeInteger", request.getMaybeInteger());
@@ -64,10 +65,8 @@ public class ServiceClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers(requestOptions)))
-                .addHeader("Content-Type", "application/json");
+                .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
-        try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();
             if (_response.isSuccessful()) {
                 return;
@@ -95,8 +94,7 @@ public class ServiceClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl)
                 .method("POST", _requestBody)
-                .headers(Headers.of(clientOptions.headers(requestOptions)))
-                .addHeader("Content-Type", "application/json");
+                .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
         try {
             Response _response = clientOptions.httpClient().newCall(_request).execute();


### PR DESCRIPTION
Previously any multipart file uploads were being sent with an `application/json` content type header. 