### PR TITLE
feature: introduce client class name config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ When enabled, generates wrapper types for each alias to increase type-safety. Fo
 
 When enabled, generates public constructors for model types.
 
+#### ✨ `client-class-name`
+
+**Type:** string
+
+**Default:** `<Organization>ApiClient`
+
+The provided string will be used as the client class name. 
+
 ## Releases
 
 All generator releases are published in the [Releases section of the GitHub repository](https://github.com/fern-api/fern-java/releases). You can directly use these version numbers in your generator configuration files.

--- a/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
+++ b/client-generator/src/main/java/com/fern/java/client/ClientGeneratorCli.java
@@ -24,9 +24,7 @@ import com.fern.ir.core.ObjectMappers;
 import com.fern.ir.model.ir.IntermediateRepresentation;
 import com.fern.java.AbstractGeneratorCli;
 import com.fern.java.AbstractPoetClassNameFactory;
-import com.fern.java.CustomConfig;
 import com.fern.java.DefaultGeneratorExecClient;
-import com.fern.java.DownloadFilesCustomConfig;
 import com.fern.java.client.generators.ApiErrorGenerator;
 import com.fern.java.client.generators.ClientOptionsGenerator;
 import com.fern.java.client.generators.EnvironmentGenerator;
@@ -49,7 +47,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig, DownloadFilesCustomConfig> {
+public final class ClientGeneratorCli
+        extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdkDownloadFilesCustomConfig> {
 
     private static final Logger log = LoggerFactory.getLogger(ClientGeneratorCli.class);
 
@@ -89,14 +88,15 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
             DefaultGeneratorExecClient generatorExecClient,
             GeneratorConfig generatorConfig,
             IntermediateRepresentation ir,
-            DownloadFilesCustomConfig customConfig) {
+            JavaSdkDownloadFilesCustomConfig customConfig) {
         ClientPoetClassNameFactory clientPoetClassNameFactory = new ClientPoetClassNameFactory(
                 customConfig.packagePrefix().map(List::of).orElseGet(Collections::emptyList));
         ClientGeneratorContext context = new ClientGeneratorContext(
                 ir,
                 generatorConfig,
-                CustomConfig.builder()
+                JavaSdkCustomConfig.builder()
                         .wrappedAliases(customConfig.wrappedAliases())
+                        .clientClassName(customConfig.clientClassName())
                         .build(),
                 clientPoetClassNameFactory);
         generateClient(context, ir);
@@ -107,7 +107,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
             DefaultGeneratorExecClient generatorExecClient,
             GeneratorConfig generatorConfig,
             IntermediateRepresentation ir,
-            CustomConfig customConfig,
+            JavaSdkCustomConfig customConfig,
             GithubOutputMode githubOutputMode) {
         ClientPoetClassNameFactory clientPoetClassNameFactory = new ClientPoetClassNameFactory(
                 AbstractPoetClassNameFactory.getPackagePrefixWithOrgAndApiName(ir, generatorConfig.getOrganization()));
@@ -138,7 +138,7 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
             DefaultGeneratorExecClient generatorExecClient,
             GeneratorConfig generatorConfig,
             IntermediateRepresentation ir,
-            CustomConfig customConfig,
+            JavaSdkCustomConfig customConfig,
             GeneratorPublishConfig publishOutputMode) {
         ClientPoetClassNameFactory clientPoetClassNameFactory = new ClientPoetClassNameFactory(
                 AbstractPoetClassNameFactory.getPackagePrefixWithOrgAndApiName(ir, generatorConfig.getOrganization()));
@@ -230,23 +230,23 @@ public final class ClientGeneratorCli extends AbstractGeneratorCli<CustomConfig,
     }
 
     @Override
-    public DownloadFilesCustomConfig getDownloadFilesCustomConfig(GeneratorConfig generatorConfig) {
+    public JavaSdkDownloadFilesCustomConfig getDownloadFilesCustomConfig(GeneratorConfig generatorConfig) {
         if (generatorConfig.getCustomConfig().isPresent()) {
             JsonNode node = ObjectMappers.JSON_MAPPER.valueToTree(
                     generatorConfig.getCustomConfig().get());
-            return ObjectMappers.JSON_MAPPER.convertValue(node, DownloadFilesCustomConfig.class);
+            return ObjectMappers.JSON_MAPPER.convertValue(node, JavaSdkDownloadFilesCustomConfig.class);
         }
-        return DownloadFilesCustomConfig.builder().build();
+        return JavaSdkDownloadFilesCustomConfig.builder().build();
     }
 
     @Override
-    public CustomConfig getCustomConfig(GeneratorConfig generatorConfig) {
+    public JavaSdkCustomConfig getCustomConfig(GeneratorConfig generatorConfig) {
         if (generatorConfig.getCustomConfig().isPresent()) {
             JsonNode node = ObjectMappers.JSON_MAPPER.valueToTree(
                     generatorConfig.getCustomConfig().get());
-            return ObjectMappers.JSON_MAPPER.convertValue(node, CustomConfig.class);
+            return ObjectMappers.JSON_MAPPER.convertValue(node, JavaSdkCustomConfig.class);
         }
-        return CustomConfig.builder().build();
+        return JavaSdkCustomConfig.builder().build();
     }
 
     public static void main(String... args) {

--- a/client-generator/src/main/java/com/fern/java/client/ClientGeneratorContext.java
+++ b/client-generator/src/main/java/com/fern/java/client/ClientGeneratorContext.java
@@ -19,14 +19,14 @@ package com.fern.java.client;
 import com.fern.generator.exec.model.config.GeneratorConfig;
 import com.fern.ir.model.ir.IntermediateRepresentation;
 import com.fern.java.AbstractGeneratorContext;
-import com.fern.java.CustomConfig;
 
-public final class ClientGeneratorContext extends AbstractGeneratorContext<ClientPoetClassNameFactory, CustomConfig> {
+public final class ClientGeneratorContext
+        extends AbstractGeneratorContext<ClientPoetClassNameFactory, JavaSdkCustomConfig> {
 
     public ClientGeneratorContext(
             IntermediateRepresentation ir,
             GeneratorConfig generatorConfig,
-            CustomConfig customConfig,
+            JavaSdkCustomConfig customConfig,
             ClientPoetClassNameFactory clientPoetClassNameFactory) {
         super(ir, generatorConfig, customConfig, clientPoetClassNameFactory);
     }

--- a/client-generator/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/client-generator/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2023 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fern.java.ICustomConfig;
+import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@StagedBuilderImmutablesStyle
+@JsonDeserialize(as = ImmutableJavaSdkCustomConfig.class)
+public interface JavaSdkCustomConfig extends ICustomConfig {
+
+    @JsonProperty("client-class-name")
+    Optional<String> clientClassName();
+
+    static ImmutableJavaSdkCustomConfig.Builder builder() {
+        return ImmutableJavaSdkCustomConfig.builder();
+    }
+}

--- a/client-generator/src/main/java/com/fern/java/client/JavaSdkDownloadFilesCustomConfig.java
+++ b/client-generator/src/main/java/com/fern/java/client/JavaSdkDownloadFilesCustomConfig.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2023 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fern.java.DownloadFilesCustomConfig;
+import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@StagedBuilderImmutablesStyle
+@JsonDeserialize(as = ImmutableJavaSdkDownloadFilesCustomConfig.class)
+public interface JavaSdkDownloadFilesCustomConfig extends DownloadFilesCustomConfig {
+
+    @JsonProperty("client-class-name")
+    Optional<String> clientClassName();
+
+    static ImmutableJavaSdkDownloadFilesCustomConfig.Builder builder() {
+        return ImmutableJavaSdkDownloadFilesCustomConfig.builder();
+    }
+}

--- a/client-generator/src/main/java/com/fern/java/client/generators/RootClientGenerator.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/RootClientGenerator.java
@@ -65,7 +65,12 @@ public final class RootClientGenerator extends AbstractFileGenerator {
             GeneratedJavaFile requestOptionsFile,
             Map<TypeId, GeneratedJavaInterface> allGeneratedInterfaces) {
         super(
-                generatorContext.getPoetClassNameFactory().getRootClassName(getRootClientName(generatorContext)),
+                generatorContext
+                        .getPoetClassNameFactory()
+                        .getRootClassName(clientGeneratorContext
+                                .getCustomConfig()
+                                .clientClassName()
+                                .orElseGet(() -> getRootClientName(generatorContext))),
                 generatorContext);
         this.generatedObjectMapper = generatedObjectMapper;
         this.clientGeneratorContext = clientGeneratorContext;

--- a/generator-utils/src/main/java/com/fern/java/AbstractGeneratorContext.java
+++ b/generator-utils/src/main/java/com/fern/java/AbstractGeneratorContext.java
@@ -68,7 +68,7 @@ public abstract class AbstractGeneratorContext<T extends AbstractPoetClassNameFa
         return generatorConfig;
     }
 
-    public final ICustomConfig getCustomConfig() {
+    public final U getCustomConfig() {
         return customConfig;
     }
 


### PR DESCRIPTION
If you specify `client-class-name` then the generated client will use the class name that is provided. 

```yaml
config: 
  client-class-name: Merge
```

The generated code will look like

```java
Merge merge = Merge.builder()
  .username("username")
  .build()

```