### PR TITLE
fix: support custom dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ When enabled, generates public constructors for model types.
 
 **Default:** `<Organization>ApiClient`
 
+#### ✨ `Custom Dependencies`
+
+**Type:** string
+
+```yaml
+custom-dependencies: 
+  - "implementation com.foo:bar:0.0.0"
+  - "testImplementation com.foo:bar:0.0.0"
+  - "api com.foo:bar:0.0.0"
+```
+
 The provided string will be used as the client class name. 
 
 ## Releases

--- a/client-generator/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/client-generator/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fern.java.ICustomConfig;
 import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -30,6 +31,9 @@ public interface JavaSdkCustomConfig extends ICustomConfig {
 
     @JsonProperty("client-class-name")
     Optional<String> clientClassName();
+
+    @JsonProperty("custom-dependencies")
+    Optional<List<String>> customDependencies();
 
     static ImmutableJavaSdkCustomConfig.Builder builder() {
         return ImmutableJavaSdkCustomConfig.builder();

--- a/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -36,7 +36,7 @@ import com.fern.java.output.GeneratedBuildGradle;
 import com.fern.java.output.GeneratedFile;
 import com.fern.java.output.ImmutableGeneratedBuildGradle;
 import com.fern.java.output.RawGeneratedFile;
-import com.fern.java.output.gradle.GradleDependency;
+import com.fern.java.output.gradle.AbstractGradleDependency;
 import com.fern.java.output.gradle.GradlePlugin;
 import com.fern.java.output.gradle.GradlePublishingConfig;
 import com.fern.java.output.gradle.GradleRepository;
@@ -218,7 +218,7 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends Do
             T customConfig,
             GeneratorPublishConfig publishOutputMode);
 
-    public abstract List<GradleDependency> getBuildGradleDependencies();
+    public abstract List<AbstractGradleDependency> getBuildGradleDependencies();
 
     public abstract List<String> getSubProjects();
 

--- a/generator-utils/src/main/java/com/fern/java/output/gradle/AbstractGradleDependency.java
+++ b/generator-utils/src/main/java/com/fern/java/output/gradle/AbstractGradleDependency.java
@@ -18,21 +18,12 @@ package com.fern.java.output.gradle;
 
 public abstract class AbstractGradleDependency {
 
-    public abstract DependencyType type();
+    public abstract GradleDependencyType type();
 
     public abstract String coordinate();
 
     @Override
     public final String toString() {
-        if (type().equals(DependencyType.TEST_IMPLEMENTATION)) {
-            return "testImplementation " + coordinate();
-        }
         return type().toString().toLowerCase() + " " + coordinate();
-    }
-
-    public enum DependencyType {
-        IMPLEMENTATION,
-        API,
-        TEST_IMPLEMENTATION,
     }
 }

--- a/generator-utils/src/main/java/com/fern/java/output/gradle/GradleDependencyType.java
+++ b/generator-utils/src/main/java/com/fern/java/output/gradle/GradleDependencyType.java
@@ -16,19 +16,25 @@
 
 package com.fern.java.output.gradle;
 
-import com.fern.java.immutables.StagedBuilderImmutablesStyle;
-import org.immutables.value.Value;
+public final class GradleDependencyType {
 
-@Value.Immutable
-@StagedBuilderImmutablesStyle
-public abstract class GradleDependency extends AbstractGradleDependency {
+    public static final GradleDependencyType IMPLEMENTATION = new GradleDependencyType("implementation");
 
-    public static GradleDependency of(String value) {
-        String gradleType = value.substring(value.indexOf(" "));
-        String coordinate = value.substring(value.indexOf(" ") + 1);
-        return ImmutableGradleDependency.builder()
-                .type(GradleDependencyType.of(gradleType))
-                .coordinate(coordinate)
-                .build();
+    public static final GradleDependencyType API = new GradleDependencyType("api");
+
+    public static final GradleDependencyType TEST_IMPLEMENTATION = new GradleDependencyType("testImplementation");
+    private final String value;
+
+    private GradleDependencyType(String value) {
+        this.value = value;
+    }
+
+    public static GradleDependencyType of(String value) {
+        return new GradleDependencyType(value);
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
     }
 }

--- a/generator-utils/src/main/java/com/fern/java/output/gradle/ParsedGradleDependency.java
+++ b/generator-utils/src/main/java/com/fern/java/output/gradle/ParsedGradleDependency.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2022 Birch Solutions Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fern.java.output.gradle;
+
+import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@StagedBuilderImmutablesStyle
+public abstract class ParsedGradleDependency extends AbstractGradleDependency {
+
+    public static final String JACKSON_JDK8_VERSION = "2.12.3";
+    public static final String JACKSON_DATABIND_VERSION = "2.13.0";
+    public static final String UTILS_VERSION = "0.0.82";
+    public static final String OKHTTP_VERSION = "4.9.3";
+    public static final String FEIGN_VERSION = "11.8";
+
+    public static final String JUNIT_DEPENDENCY = "5.8.2";
+
+    public abstract String group();
+
+    public abstract String artifact();
+
+    public abstract String version();
+
+    @Override
+    public final String coordinate() {
+        return "'" + group() + ":" + artifact() + ":" + version() + "'";
+    }
+
+    public static ImmutableParsedGradleDependency.TypeBuildStage builder() {
+        return ImmutableParsedGradleDependency.builder();
+    }
+}

--- a/generator-utils/src/main/java/com/fern/java/output/gradle/RootProjectGradleDependency.java
+++ b/generator-utils/src/main/java/com/fern/java/output/gradle/RootProjectGradleDependency.java
@@ -21,8 +21,8 @@ public final class RootProjectGradleDependency extends AbstractGradleDependency 
     public static final RootProjectGradleDependency INSTANCE = new RootProjectGradleDependency();
 
     @Override
-    public DependencyType type() {
-        return DependencyType.IMPLEMENTATION;
+    public GradleDependencyType type() {
+        return GradleDependencyType.IMPLEMENTATION;
     }
 
     @Override

--- a/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
+++ b/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
@@ -18,11 +18,11 @@ package com.fern.java.output;
 
 import com.fern.generator.exec.model.logging.MavenCoordinate;
 import com.fern.java.output.gradle.AbstractGradleDependency;
-import com.fern.java.output.gradle.AbstractGradleDependency.DependencyType;
-import com.fern.java.output.gradle.GradleDependency;
+import com.fern.java.output.gradle.GradleDependencyType;
 import com.fern.java.output.gradle.GradlePlugin;
 import com.fern.java.output.gradle.GradlePublishingConfig;
 import com.fern.java.output.gradle.GradleRepository;
+import com.fern.java.output.gradle.ParsedGradleDependency;
 import com.fern.java.output.gradle.RootProjectGradleDependency;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -37,11 +37,11 @@ public class GeneratedBuildGradleTest {
                 .version("0.0.0")
                 .build();
         List<AbstractGradleDependency> deps = List.of(
-                GradleDependency.builder()
-                        .type(DependencyType.IMPLEMENTATION)
+                ParsedGradleDependency.builder()
+                        .type(GradleDependencyType.IMPLEMENTATION)
                         .group("io.github.fern-api")
                         .artifact("jersy-utils")
-                        .version(GradleDependency.UTILS_VERSION)
+                        .version(ParsedGradleDependency.UTILS_VERSION)
                         .build(),
                 RootProjectGradleDependency.INSTANCE);
         GeneratedBuildGradle buildGradle = GeneratedBuildGradle.builder()

--- a/model-generator/src/main/java/com/fern/java/model/ModelGeneratorCli.java
+++ b/model-generator/src/main/java/com/fern/java/model/ModelGeneratorCli.java
@@ -30,8 +30,9 @@ import com.fern.java.generators.DateTimeDeserializerGenerator;
 import com.fern.java.generators.ObjectMappersGenerator;
 import com.fern.java.generators.TypesGenerator;
 import com.fern.java.generators.TypesGenerator.Result;
-import com.fern.java.output.gradle.AbstractGradleDependency.DependencyType;
-import com.fern.java.output.gradle.GradleDependency;
+import com.fern.java.output.gradle.AbstractGradleDependency;
+import com.fern.java.output.gradle.GradleDependencyType;
+import com.fern.java.output.gradle.ParsedGradleDependency;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,25 +86,25 @@ public final class ModelGeneratorCli extends AbstractGeneratorCli<CustomConfig, 
     }
 
     @Override
-    public List<GradleDependency> getBuildGradleDependencies() {
+    public List<AbstractGradleDependency> getBuildGradleDependencies() {
         return List.of(
-                GradleDependency.builder()
-                        .type(DependencyType.API)
+                ParsedGradleDependency.builder()
+                        .type(GradleDependencyType.API)
                         .group("com.fasterxml.jackson.core")
                         .artifact("jackson-databind")
-                        .version(GradleDependency.JACKSON_DATABIND_VERSION)
+                        .version(ParsedGradleDependency.JACKSON_DATABIND_VERSION)
                         .build(),
-                GradleDependency.builder()
-                        .type(DependencyType.API)
+                ParsedGradleDependency.builder()
+                        .type(GradleDependencyType.API)
                         .group("com.fasterxml.jackson.datatype")
                         .artifact("jackson-datatype-jdk8")
-                        .version(GradleDependency.JACKSON_JDK8_VERSION)
+                        .version(ParsedGradleDependency.JACKSON_JDK8_VERSION)
                         .build(),
-                GradleDependency.builder()
-                        .type(DependencyType.API)
+                ParsedGradleDependency.builder()
+                        .type(GradleDependencyType.API)
                         .group("com.fasterxml.jackson.datatype")
                         .artifact("jackson-datatype-jsr310")
-                        .version(GradleDependency.JACKSON_JDK8_VERSION)
+                        .version(ParsedGradleDependency.JACKSON_JDK8_VERSION)
                         .build());
     }
 

--- a/spring-server-generator/src/main/java/com/fern/java/spring/SpringGeneratorCli.java
+++ b/spring-server-generator/src/main/java/com/fern/java/spring/SpringGeneratorCli.java
@@ -34,7 +34,7 @@ import com.fern.java.generators.TypesGenerator.Result;
 import com.fern.java.output.GeneratedAuthFiles;
 import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
-import com.fern.java.output.gradle.GradleDependency;
+import com.fern.java.output.gradle.AbstractGradleDependency;
 import com.fern.java.spring.generators.ApiExceptionGenerator;
 import com.fern.java.spring.generators.ErrorBodyGenerator;
 import com.fern.java.spring.generators.ExceptionGenerator;
@@ -149,7 +149,7 @@ public final class SpringGeneratorCli
     }
 
     @Override
-    public List<GradleDependency> getBuildGradleDependencies() {
+    public List<AbstractGradleDependency> getBuildGradleDependencies() {
         return List.of();
     }
 


### PR DESCRIPTION
z- Add a custom config to support adding arbitrary dependencies to the Java SDK
```yaml
config:
  custom-dependencies: 
    - "implementation com.foo:bar:0.0.0"
    - "testImplementation com.foo:bar:0.0.0"
    - "api com.foo:bar:0.0.0"
```