### PR TITLE
fix: sdk sends request body properties that are inherited

### DIFF
--- a/client-generator/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
@@ -174,6 +174,7 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
                             .map(objectProperty ->
                                     generatedObject.objectPropertyGetters().get(objectProperty))
                             .collect(Collectors.toList()))
+                    .addAllProperties(generatedObject.extendedObjectPropertyGetters())
                     .build();
         }
 

--- a/generator-utils/src/main/java/com/fern/java/generators/ObjectGenerator.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/ObjectGenerator.java
@@ -69,6 +69,7 @@ public final class ObjectGenerator extends AbstractFileGenerator {
         PoetTypeNameMapper poetTypeNameMapper = generatorContext.getPoetTypeNameMapper();
         List<EnrichedObjectProperty> enrichedObjectProperties = new ArrayList<>();
         Map<ObjectProperty, EnrichedObjectProperty> objectPropertyGetters = new HashMap<>();
+        List<EnrichedObjectProperty> extendedPropertyGetters = new ArrayList<>();
         if (selfInterface.isEmpty()) {
             enrichedObjectProperties = objectTypeDeclaration.getProperties().stream()
                     .map(objectProperty -> {
@@ -106,7 +107,10 @@ public final class ObjectGenerator extends AbstractFileGenerator {
                             .addAllInterfaceProperties(enrichedProperties)
                             .build();
                 })
-                .forEach(implementsInterfaces::add);
+                .forEach(implementsInterface -> {
+                    extendedPropertyGetters.addAll(implementsInterface.interfaceProperties());
+                    implementsInterfaces.add(implementsInterface);
+                });
         ObjectTypeSpecGenerator genericObjectGenerator = new ObjectTypeSpecGenerator(
                 className,
                 generatorContext.getPoetClassNameFactory().getObjectMapperClassName(),
@@ -121,6 +125,7 @@ public final class ObjectGenerator extends AbstractFileGenerator {
                 .className(className)
                 .javaFile(javaFile)
                 .putAllObjectPropertyGetters(objectPropertyGetters)
+                .addAllExtendedObjectPropertyGetters(extendedPropertyGetters)
                 .build();
     }
 

--- a/generator-utils/src/main/java/com/fern/java/output/GeneratedObject.java
+++ b/generator-utils/src/main/java/com/fern/java/output/GeneratedObject.java
@@ -19,6 +19,7 @@ package com.fern.java.output;
 import com.fern.ir.model.types.ObjectProperty;
 import com.fern.java.generators.object.EnrichedObjectProperty;
 import com.fern.java.immutables.StagedBuilderImmutablesStyle;
+import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -27,6 +28,8 @@ import org.immutables.value.Value;
 public abstract class GeneratedObject extends AbstractGeneratedJavaFile {
 
     public abstract Map<ObjectProperty, EnrichedObjectProperty> objectPropertyGetters();
+
+    public abstract List<EnrichedObjectProperty> extendedObjectPropertyGetters();
 
     public static ImmutableGeneratedObject.ClassNameBuildStage builder() {
         return ImmutableGeneratedObject.builder();

--- a/generator-utils/src/main/java/com/fern/java/output/gradle/AbstractGradleDependency.java
+++ b/generator-utils/src/main/java/com/fern/java/output/gradle/AbstractGradleDependency.java
@@ -24,6 +24,6 @@ public abstract class AbstractGradleDependency {
 
     @Override
     public final String toString() {
-        return type().toString().toLowerCase() + " " + coordinate();
+        return type().toString() + " " + coordinate();
     }
 }


### PR DESCRIPTION
The java SDK was previously not sending request body properties that were inherited.