### PR TITLE
fix: only prefix parameters with underscore if necessary

### DIFF
--- a/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
+++ b/client-generator/src/main/java/com/fern/java/client/generators/endpoint/AbstractEndpointWriter.java
@@ -81,7 +81,6 @@ public abstract class AbstractEndpointWriter {
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String APPLICATION_JSON_HEADER = "application/json";
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
-    public static final String HTTP_URL_NAME = "_httpUrl";
     public static final String REQUEST_NAME = "_request";
     public static final String REQUEST_BUILDER_NAME = "_requestBuilder";
     public static final String REQUEST_BODY_NAME = "_requestBody";
@@ -135,7 +134,9 @@ public abstract class AbstractEndpointWriter {
 
         // Step 4: Get http client initializer
         HttpUrlBuilder httpUrlBuilder = new HttpUrlBuilder(
-                HTTP_URL_NAME,
+                getHttpUrlName(endpointMethodBuilder.parameters.stream()
+                        .map(parameterSpec -> parameterSpec.name)
+                        .collect(Collectors.toList())),
                 sdkRequest()
                         .map(sdkRequest -> sdkRequest
                                 .getRequestParameterName()
@@ -299,6 +300,13 @@ public abstract class AbstractEndpointWriter {
         } else {
             throw new RuntimeException("Generated Environments class was unknown : " + generatedEnvironmentsClass);
         }
+    }
+
+    private String getHttpUrlName(List<String> paramNames) {
+        if (paramNames.contains("httpUrl")) {
+            return "_httpUrl";
+        }
+        return "httpUrl";
     }
 
     private List<ParameterSpec> getPathParameters() {

--- a/seed/basic-auth/src/main/java/com/seed/basicAuth/resources/basicauth/BasicAuthClient.java
+++ b/seed/basic-auth/src/main/java/com/seed/basicAuth/resources/basicauth/BasicAuthClient.java
@@ -27,12 +27,12 @@ public class BasicAuthClient {
     }
 
     public boolean getWithBasicAuth(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("basic-auth")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -55,7 +55,7 @@ public class BasicAuthClient {
     }
 
     public boolean postWithBasicAuth(Object request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("basic-auth")
                 .build();
@@ -67,7 +67,7 @@ public class BasicAuthClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/bytes/src/main/java/com/seed/bytes/resources/service/ServiceClient.java
+++ b/seed/bytes/src/main/java/com/seed/bytes/resources/service/ServiceClient.java
@@ -26,13 +26,13 @@ public class ServiceClient {
     }
 
     public void upload(byte[] request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("upload-content")
                 .build();
         RequestBody _requestBody = RequestBody.create(request);
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/octet-stream")

--- a/seed/custom-auth/src/main/java/com/seed/customAuth/resources/customauth/CustomAuthClient.java
+++ b/seed/custom-auth/src/main/java/com/seed/customAuth/resources/customauth/CustomAuthClient.java
@@ -27,12 +27,12 @@ public class CustomAuthClient {
     }
 
     public boolean getWithCustomAuth(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("custom-auth")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -55,7 +55,7 @@ public class CustomAuthClient {
     }
 
     public boolean postWithCustomAuth(Object request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("custom-auth")
                 .build();
@@ -67,7 +67,7 @@ public class CustomAuthClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/error-property/src/main/java/com/seed/errorProperty/resources/propertybasederror/PropertyBasedErrorClient.java
+++ b/seed/error-property/src/main/java/com/seed/errorProperty/resources/propertybasederror/PropertyBasedErrorClient.java
@@ -25,12 +25,12 @@ public class PropertyBasedErrorClient {
     }
 
     public String throwError(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("property-based-error")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/container/ContainerClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/container/ContainerClient.java
@@ -33,7 +33,7 @@ public class ContainerClient {
     }
 
     public List<String> getAndReturnListOfPrimitives(List<String> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("list-of-primitives")
@@ -46,7 +46,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -71,7 +71,7 @@ public class ContainerClient {
 
     public List<ObjectWithRequiredField> getAndReturnListOfObjects(
             List<ObjectWithRequiredField> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("list-of-objects")
@@ -84,7 +84,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -108,7 +108,7 @@ public class ContainerClient {
     }
 
     public Set<String> getAndReturnSetOfPrimitives(Set<String> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("set-of-primitives")
@@ -121,7 +121,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -146,7 +146,7 @@ public class ContainerClient {
 
     public Set<ObjectWithRequiredField> getAndReturnSetOfObjects(
             Set<ObjectWithRequiredField> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("set-of-objects")
@@ -159,7 +159,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -183,7 +183,7 @@ public class ContainerClient {
     }
 
     public Map<String, String> getAndReturnMapPrimToPrim(Map<String, String> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("map-prim-to-prim")
@@ -196,7 +196,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -222,7 +222,7 @@ public class ContainerClient {
 
     public Map<String, ObjectWithRequiredField> getAndReturnMapOfPrimToObject(
             Map<String, ObjectWithRequiredField> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("map-prim-to-object")
@@ -235,7 +235,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -260,7 +260,7 @@ public class ContainerClient {
 
     public Optional<ObjectWithRequiredField> getAndReturnOptional(
             Optional<ObjectWithRequiredField> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("container")
                 .addPathSegments("opt-objects")
@@ -273,7 +273,7 @@ public class ContainerClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/EnumClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/EnumClient.java
@@ -28,7 +28,7 @@ public class EnumClient {
     }
 
     public WeatherReport getAndReturnEnum(WeatherReport request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("enum")
                 .build();
@@ -40,7 +40,7 @@ public class EnumClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/HttpMethodsClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/HttpMethodsClient.java
@@ -29,13 +29,13 @@ public class HttpMethodsClient {
     }
 
     public String testGet(String id, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("http-methods")
                 .addPathSegment(id)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -58,7 +58,7 @@ public class HttpMethodsClient {
     }
 
     public ObjectWithOptionalField testPost(ObjectWithRequiredField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("http-methods")
                 .build();
@@ -70,7 +70,7 @@ public class HttpMethodsClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -93,7 +93,7 @@ public class HttpMethodsClient {
     }
 
     public ObjectWithOptionalField testPut(String id, ObjectWithRequiredField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("http-methods")
                 .addPathSegment(id)
@@ -106,7 +106,7 @@ public class HttpMethodsClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("PUT", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -130,7 +130,7 @@ public class HttpMethodsClient {
 
     public ObjectWithOptionalField testPatch(
             String id, ObjectWithOptionalField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("http-methods")
                 .addPathSegment(id)
@@ -143,7 +143,7 @@ public class HttpMethodsClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("PATCH", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -170,13 +170,13 @@ public class HttpMethodsClient {
     }
 
     public boolean testDelete(String id, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("http-methods")
                 .addPathSegment(id)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("DELETE", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/object/ObjectClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/object/ObjectClient.java
@@ -32,7 +32,7 @@ public class ObjectClient {
 
     public ObjectWithOptionalField getAndReturnWithOptionalField(
             ObjectWithOptionalField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("object")
                 .addPathSegments("get-and-return-with-optional-field")
@@ -45,7 +45,7 @@ public class ObjectClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -73,7 +73,7 @@ public class ObjectClient {
 
     public ObjectWithRequiredField getAndReturnWithRequiredField(
             ObjectWithRequiredField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("object")
                 .addPathSegments("get-and-return-with-required-field")
@@ -86,7 +86,7 @@ public class ObjectClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -110,7 +110,7 @@ public class ObjectClient {
 
     public NestedObjectWithOptionalField getAndReturnNestedWithOptionalField(
             NestedObjectWithOptionalField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("object")
                 .addPathSegments("get-and-return-nested-with-optional-field")
@@ -123,7 +123,7 @@ public class ObjectClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -153,7 +153,7 @@ public class ObjectClient {
 
     public NestedObjectWithRequiredField getAndReturnNestedWithRequiredField(
             NestedObjectWithRequiredField request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("object")
                 .addPathSegments("get-and-return-nested-with-required-field")
@@ -166,7 +166,7 @@ public class ObjectClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/params/ParamsClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/params/ParamsClient.java
@@ -30,14 +30,14 @@ public class ParamsClient {
     }
 
     public String getWithPath(String param, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("params")
                 .addPathSegments("path")
                 .addPathSegment(param)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -60,15 +60,14 @@ public class ParamsClient {
     }
 
     public void getWithQuery(GetWithQuery request, RequestOptions requestOptions) {
-        HttpUrl.Builder _httpUrl = HttpUrl.parse(
-                        this.clientOptions.environment().getUrl())
+        HttpUrl.Builder httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("params");
-        _httpUrl.addQueryParameter("query", request.getQuery());
-        _httpUrl.addQueryParameter("number", Integer.toString(request.getNumber()));
+        httpUrl.addQueryParameter("query", request.getQuery());
+        httpUrl.addQueryParameter("number", Integer.toString(request.getNumber()));
         RequestBody _requestBody = null;
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl.build())
+                .url(httpUrl.build())
                 .method("GET", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
@@ -90,15 +89,14 @@ public class ParamsClient {
     }
 
     public void getWithAllowMultipleQuery(GetWithMultipleQuery request, RequestOptions requestOptions) {
-        HttpUrl.Builder _httpUrl = HttpUrl.parse(
-                        this.clientOptions.environment().getUrl())
+        HttpUrl.Builder httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("params");
-        _httpUrl.addQueryParameter("query", request.getQuery());
-        _httpUrl.addQueryParameter("numer", Integer.toString(request.getNumer()));
+        httpUrl.addQueryParameter("query", request.getQuery());
+        httpUrl.addQueryParameter("numer", Integer.toString(request.getNumer()));
         RequestBody _requestBody = null;
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl.build())
+                .url(httpUrl.build())
                 .method("GET", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
@@ -120,16 +118,15 @@ public class ParamsClient {
     }
 
     public void getWithPathAndQuery(String param, GetWithPathAndQuery request, RequestOptions requestOptions) {
-        HttpUrl.Builder _httpUrl = HttpUrl.parse(
-                        this.clientOptions.environment().getUrl())
+        HttpUrl.Builder httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("params")
                 .addPathSegments("path")
                 .addPathSegment(param);
-        _httpUrl.addQueryParameter("query", request.getQuery());
+        httpUrl.addQueryParameter("query", request.getQuery());
         RequestBody _requestBody = null;
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl.build())
+                .url(httpUrl.build())
                 .method("GET", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
@@ -151,7 +148,7 @@ public class ParamsClient {
     }
 
     public String modifyWithPath(String param, String request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("params")
                 .addPathSegments("path")
@@ -165,7 +162,7 @@ public class ParamsClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("PUT", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/PrimitiveClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/PrimitiveClient.java
@@ -29,7 +29,7 @@ public class PrimitiveClient {
     }
 
     public String getAndReturnString(String request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("string")
@@ -42,7 +42,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -65,7 +65,7 @@ public class PrimitiveClient {
     }
 
     public int getAndReturnInt(int request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("integer")
@@ -78,7 +78,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -101,7 +101,7 @@ public class PrimitiveClient {
     }
 
     public long getAndReturnLong(long request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("long")
@@ -114,7 +114,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -137,7 +137,7 @@ public class PrimitiveClient {
     }
 
     public double getAndReturnDouble(double request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("double")
@@ -150,7 +150,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -173,7 +173,7 @@ public class PrimitiveClient {
     }
 
     public boolean getAndReturnBool(boolean request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("boolean")
@@ -186,7 +186,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -209,7 +209,7 @@ public class PrimitiveClient {
     }
 
     public OffsetDateTime getAndReturnDatetime(OffsetDateTime request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("datetime")
@@ -222,7 +222,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -245,7 +245,7 @@ public class PrimitiveClient {
     }
 
     public String getAndReturnDate(String request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("date")
@@ -258,7 +258,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -281,7 +281,7 @@ public class PrimitiveClient {
     }
 
     public UUID getAndReturnUuid(UUID request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("uuid")
@@ -294,7 +294,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -317,7 +317,7 @@ public class PrimitiveClient {
     }
 
     public byte[] getAndReturnBase64(byte[] request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("primitive")
                 .addPathSegments("base64")
@@ -330,7 +330,7 @@ public class PrimitiveClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/union/UnionClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/endpoints/union/UnionClient.java
@@ -28,7 +28,7 @@ public class UnionClient {
     }
 
     public Animal getAndReturnUnion(Animal request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("union")
                 .build();
@@ -40,7 +40,7 @@ public class UnionClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/inlinedrequests/InlinedRequestsClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/inlinedrequests/InlinedRequestsClient.java
@@ -30,7 +30,7 @@ public class InlinedRequestsClient {
 
     public ObjectWithOptionalField postWithObjectBodyandResponse(
             PostWithObjectBody request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("req-bodies")
                 .addPathSegments("object")
@@ -43,7 +43,7 @@ public class InlinedRequestsClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/noauth/NoAuthClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/noauth/NoAuthClient.java
@@ -27,7 +27,7 @@ public class NoAuthClient {
     }
 
     public boolean postWithNoAuth(Object request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("no-auth")
                 .build();
@@ -39,7 +39,7 @@ public class NoAuthClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/noreqbody/NoReqBodyClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/noreqbody/NoReqBodyClient.java
@@ -27,12 +27,12 @@ public class NoReqBodyClient {
     }
 
     public ObjectWithOptionalField getWithNoRequestBody(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("no-req-body")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -55,12 +55,12 @@ public class NoReqBodyClient {
     }
 
     public String postWithNoRequestBody(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("no-req-body")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", RequestBody.create("", null))
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/reqwithheaders/ReqWithHeadersClient.java
+++ b/seed/exhaustive/src/main/java/com/seed/exhaustive/resources/reqwithheaders/ReqWithHeadersClient.java
@@ -28,7 +28,7 @@ public class ReqWithHeadersClient {
     }
 
     public void getWithCustomHeader(ReqWithHeaders request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("test-headers")
                 .addPathSegments("custom-header")
@@ -42,7 +42,7 @@ public class ReqWithHeadersClient {
             throw new RuntimeException(e);
         }
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");

--- a/seed/file-download/src/main/java/com/seed/fileDownload/resources/service/ServiceClient.java
+++ b/seed/file-download/src/main/java/com/seed/fileDownload/resources/service/ServiceClient.java
@@ -27,11 +27,11 @@ public class ServiceClient {
     }
 
     public InputStream downloadFile(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", RequestBody.create("", null))
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
+++ b/seed/file-upload/src/main/java/com/seed/fileUpload/resources/service/ServiceClient.java
@@ -31,7 +31,7 @@ public class ServiceClient {
     }
 
     public void post(File file, Optional<File> maybeFile, MyRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .build();
         MultipartBody.Builder _multipartBody = new MultipartBody.Builder().setType(MultipartBody.FORM);
@@ -85,7 +85,7 @@ public class ServiceClient {
         }
         RequestBody _requestBody = _multipartBody.build();
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();
@@ -107,7 +107,7 @@ public class ServiceClient {
     }
 
     public void justFile(File file, JustFileRequet request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("just-file")
                 .build();
@@ -119,7 +119,7 @@ public class ServiceClient {
         }
         RequestBody _requestBody = _multipartBody.build();
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)));
         Request _request = _requestBuilder.build();

--- a/seed/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/resources/ec2/Ec2Client.java
+++ b/seed/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/resources/ec2/Ec2Client.java
@@ -28,7 +28,7 @@ public class Ec2Client {
     }
 
     public void bootInstance(BootInstanceRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getec2URL())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getec2URL())
                 .newBuilder()
                 .addPathSegments("ec2")
                 .addPathSegments("boot")
@@ -41,7 +41,7 @@ public class Ec2Client {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/resources/s3/S3Client.java
+++ b/seed/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/resources/s3/S3Client.java
@@ -28,7 +28,7 @@ public class S3Client {
     }
 
     public String getPresignedUrl(GetPresignedUrlRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().gets3URL())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().gets3URL())
                 .newBuilder()
                 .addPathSegments("s3")
                 .addPathSegments("presigned-url")
@@ -41,7 +41,7 @@ public class S3Client {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/no-environment/src/main/java/com/seed/noEnvironment/resources/dummy/DummyClient.java
+++ b/seed/no-environment/src/main/java/com/seed/noEnvironment/resources/dummy/DummyClient.java
@@ -25,12 +25,12 @@ public class DummyClient {
     }
 
     public String getDummy(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("dummy")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/plain-text/src/main/java/com/seed/plainText/resources/service/ServiceClient.java
+++ b/seed/plain-text/src/main/java/com/seed/plainText/resources/service/ServiceClient.java
@@ -26,12 +26,12 @@ public class ServiceClient {
     }
 
     public String getText(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("text")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", RequestBody.create("", null))
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/resources/dummy/DummyClient.java
+++ b/seed/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/resources/dummy/DummyClient.java
@@ -25,12 +25,12 @@ public class DummyClient {
     }
 
     public String getDummy(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("dummy")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/resources/dummy/DummyClient.java
+++ b/seed/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/resources/dummy/DummyClient.java
@@ -25,12 +25,12 @@ public class DummyClient {
     }
 
     public String getDummy(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("dummy")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/admin/AdminClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/admin/AdminClient.java
@@ -37,7 +37,7 @@ public class AdminClient {
 
     public void updateTestSubmissionStatus(
             UUID submissionId, TestSubmissionStatus request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-test-submission-status")
@@ -51,7 +51,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -75,7 +75,7 @@ public class AdminClient {
 
     public void sendTestSubmissionUpdate(
             UUID submissionId, TestSubmissionUpdate request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-test-submission-status-v2")
@@ -89,7 +89,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -113,7 +113,7 @@ public class AdminClient {
 
     public void updateWorkspaceSubmissionStatus(
             UUID submissionId, WorkspaceSubmissionStatus request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-workspace-submission-status")
@@ -127,7 +127,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -151,7 +151,7 @@ public class AdminClient {
 
     public void sendWorkspaceSubmissionUpdate(
             UUID submissionId, WorkspaceSubmissionUpdate request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-workspace-submission-status-v2")
@@ -165,7 +165,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -189,7 +189,7 @@ public class AdminClient {
 
     public void storeTracedTestCase(
             UUID submissionId, String testCaseId, StoreTracedTestCaseRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-test-trace/submission")
@@ -205,7 +205,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -229,7 +229,7 @@ public class AdminClient {
 
     public void storeTracedTestCaseV2(
             UUID submissionId, String testCaseId, List<TraceResponseV2> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-test-trace-v2/submission")
@@ -245,7 +245,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -269,7 +269,7 @@ public class AdminClient {
 
     public void storeTracedWorkspace(
             UUID submissionId, StoreTracedWorkspaceRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-workspace-trace/submission")
@@ -283,7 +283,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -307,7 +307,7 @@ public class AdminClient {
 
     public void storeTracedWorkspaceV2(
             UUID submissionId, List<TraceResponseV2> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("admin")
                 .addPathSegments("store-workspace-trace-v2/submission")
@@ -321,7 +321,7 @@ public class AdminClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/homepage/HomepageClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/homepage/HomepageClient.java
@@ -29,12 +29,12 @@ public class HomepageClient {
     }
 
     public List<String> getHomepageProblems(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("homepage-problems")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -58,7 +58,7 @@ public class HomepageClient {
     }
 
     public void setHomepageProblems(List<String> request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("homepage-problems")
                 .build();
@@ -70,7 +70,7 @@ public class HomepageClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/migration/MigrationClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/migration/MigrationClient.java
@@ -31,14 +31,14 @@ public class MigrationClient {
 
     public List<Migration> getAttemptedMigrations(
             GetAttemptedMigrationsRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("migration-info")
                 .addPathSegments("all")
                 .build();
         RequestBody _requestBody = null;
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");

--- a/seed/trace/src/main/java/com/seed/trace/resources/playlist/PlaylistClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/playlist/PlaylistClient.java
@@ -34,15 +34,14 @@ public class PlaylistClient {
     }
 
     public Playlist createPlaylist(int serviceParam, CreatePlaylistRequest request, RequestOptions requestOptions) {
-        HttpUrl.Builder _httpUrl = HttpUrl.parse(
-                        this.clientOptions.environment().getUrl())
+        HttpUrl.Builder httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v2/playlist")
                 .addPathSegment(Integer.toString(serviceParam))
                 .addPathSegments("create");
-        _httpUrl.addQueryParameter("datetime", request.getDatetime().toString());
+        httpUrl.addQueryParameter("datetime", request.getDatetime().toString());
         if (request.getOptionalDatetime().isPresent()) {
-            _httpUrl.addQueryParameter(
+            httpUrl.addQueryParameter(
                     "optionalDatetime", request.getOptionalDatetime().get().toString());
         }
         RequestBody _requestBody;
@@ -54,7 +53,7 @@ public class PlaylistClient {
             throw new RuntimeException(e);
         }
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl.build())
+                .url(httpUrl.build())
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
@@ -77,25 +76,24 @@ public class PlaylistClient {
     }
 
     public List<Playlist> getPlaylists(int serviceParam, GetPlaylistsRequest request, RequestOptions requestOptions) {
-        HttpUrl.Builder _httpUrl = HttpUrl.parse(
-                        this.clientOptions.environment().getUrl())
+        HttpUrl.Builder httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v2/playlist")
                 .addPathSegment(Integer.toString(serviceParam))
                 .addPathSegments("all");
         if (request.getLimit().isPresent()) {
-            _httpUrl.addQueryParameter("limit", request.getLimit().get().toString());
+            httpUrl.addQueryParameter("limit", request.getLimit().get().toString());
         }
-        _httpUrl.addQueryParameter("otherField", request.getOtherField());
-        _httpUrl.addQueryParameter("multiLineDocs", request.getMultiLineDocs());
+        httpUrl.addQueryParameter("otherField", request.getOtherField());
+        httpUrl.addQueryParameter("multiLineDocs", request.getMultiLineDocs());
         if (request.getOptionalMultipleField().isPresent()) {
-            _httpUrl.addQueryParameter(
+            httpUrl.addQueryParameter(
                     "optionalMultipleField", request.getOptionalMultipleField().get());
         }
-        _httpUrl.addQueryParameter("multipleField", request.getMultipleField());
+        httpUrl.addQueryParameter("multipleField", request.getMultipleField());
         RequestBody _requestBody = null;
         Request.Builder _requestBuilder = new Request.Builder()
-                .url(_httpUrl.build())
+                .url(httpUrl.build())
                 .method("GET", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
@@ -119,14 +117,14 @@ public class PlaylistClient {
     }
 
     public Playlist getPlaylist(int serviceParam, String playlistId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v2/playlist")
                 .addPathSegment(Integer.toString(serviceParam))
                 .addPathSegment(playlistId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -154,7 +152,7 @@ public class PlaylistClient {
             String playlistId,
             Optional<UpdatePlaylistRequest> request,
             RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v2/playlist")
                 .addPathSegment(Integer.toString(serviceParam))
@@ -168,7 +166,7 @@ public class PlaylistClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("PUT", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -196,14 +194,14 @@ public class PlaylistClient {
     }
 
     public void deletePlaylist(int serviceParam, String playlistId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("v2/playlist")
                 .addPathSegment(Integer.toString(serviceParam))
                 .addPathSegment(playlistId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("DELETE", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();

--- a/seed/trace/src/main/java/com/seed/trace/resources/problem/ProblemClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/problem/ProblemClient.java
@@ -32,7 +32,7 @@ public class ProblemClient {
     }
 
     public CreateProblemResponse createProblem(CreateProblemRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problem-crud")
                 .addPathSegments("create")
@@ -45,7 +45,7 @@ public class ProblemClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -69,7 +69,7 @@ public class ProblemClient {
 
     public UpdateProblemResponse updateProblem(
             String problemId, CreateProblemRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problem-crud")
                 .addPathSegments("update")
@@ -83,7 +83,7 @@ public class ProblemClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -106,14 +106,14 @@ public class ProblemClient {
     }
 
     public void deleteProblem(String problemId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problem-crud")
                 .addPathSegments("delete")
                 .addPathSegment(problemId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("DELETE", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
@@ -136,7 +136,7 @@ public class ProblemClient {
 
     public GetDefaultStarterFilesResponse getDefaultStarterFiles(
             GetDefaultStarterFilesRequest request, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problem-crud")
                 .addPathSegments("default-starter-files")
@@ -149,7 +149,7 @@ public class ProblemClient {
             throw new RuntimeException(e);
         }
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", _requestBody)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/submission/SubmissionClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/submission/SubmissionClient.java
@@ -31,14 +31,14 @@ public class SubmissionClient {
     }
 
     public ExecutionSessionResponse createExecutionSession(Language language, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sessions")
                 .addPathSegments("create-session")
                 .addPathSegment(language.toString())
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("POST", RequestBody.create("", null))
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -61,13 +61,13 @@ public class SubmissionClient {
     }
 
     public Optional<ExecutionSessionResponse> getExecutionSession(String sessionId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sessions")
                 .addPathSegment(sessionId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -91,14 +91,14 @@ public class SubmissionClient {
     }
 
     public void stopExecutionSession(String sessionId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sessions")
                 .addPathSegments("stop")
                 .addPathSegment(sessionId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("DELETE", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
@@ -120,13 +120,13 @@ public class SubmissionClient {
     }
 
     public GetExecutionSessionStateResponse getExecutionSessionsState(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sessions")
                 .addPathSegments("execution-sessions-state")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/sysprop/SyspropClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/sysprop/SyspropClient.java
@@ -28,7 +28,7 @@ public class SyspropClient {
     }
 
     public void setNumWarmInstances(Language language, int numWarmInstances, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sysprop")
                 .addPathSegments("num-warm-instances")
@@ -36,7 +36,7 @@ public class SyspropClient {
                 .addPathSegment(Integer.toString(numWarmInstances))
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("PUT", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();
@@ -58,13 +58,13 @@ public class SyspropClient {
     }
 
     public Map<Language, Integer> getNumWarmInstances(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("sysprop")
                 .addPathSegments("num-warm-instances")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/v2/V2Client.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/v2/V2Client.java
@@ -35,11 +35,11 @@ public class V2Client {
     }
 
     public void test(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .build();

--- a/seed/trace/src/main/java/com/seed/trace/resources/v2/problem/ProblemClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/v2/problem/ProblemClient.java
@@ -29,13 +29,13 @@ public class ProblemClient {
     }
 
     public List<LightweightProblemInfoV2> getLightweightProblems(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("lightweight-problem-info")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -59,13 +59,13 @@ public class ProblemClient {
     }
 
     public List<ProblemInfoV2> getProblems(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -89,14 +89,14 @@ public class ProblemClient {
     }
 
     public ProblemInfoV2 getLatestProblem(String problemId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
                 .addPathSegment(problemId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -119,7 +119,7 @@ public class ProblemClient {
     }
 
     public ProblemInfoV2 getProblemVersion(String problemId, int problemVersion, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
@@ -128,7 +128,7 @@ public class ProblemClient {
                 .addPathSegment(Integer.toString(problemVersion))
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")

--- a/seed/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/ProblemClient.java
+++ b/seed/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/ProblemClient.java
@@ -29,13 +29,13 @@ public class ProblemClient {
     }
 
     public List<LightweightProblemInfoV2> getLightweightProblems(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("lightweight-problem-info")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -59,13 +59,13 @@ public class ProblemClient {
     }
 
     public List<ProblemInfoV2> getProblems(RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -89,14 +89,14 @@ public class ProblemClient {
     }
 
     public ProblemInfoV2 getLatestProblem(String problemId, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
                 .addPathSegment(problemId)
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")
@@ -119,7 +119,7 @@ public class ProblemClient {
     }
 
     public ProblemInfoV2 getProblemVersion(String problemId, int problemVersion, RequestOptions requestOptions) {
-        HttpUrl _httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("problems-v2")
                 .addPathSegments("problem-info")
@@ -128,7 +128,7 @@ public class ProblemClient {
                 .addPathSegment(Integer.toString(problemVersion))
                 .build();
         Request _request = new Request.Builder()
-                .url(_httpUrl)
+                .url(httpUrl)
                 .method("GET", null)
                 .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json")


### PR DESCRIPTION
`_httpUrl` -> `httpUrl`