### PR TITLE
[fix] treat getters of reserved words special as well

### DIFF
--- a/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -56,16 +56,17 @@ public interface EnrichedObjectProperty {
             return Optional.empty();
         }
         return Optional.of(FieldSpec.builder(
-                        poetTypeName(),
-                        KeyWordUtils.getKeyWordCompatibleName(camelCaseKey()),
-                        Modifier.PRIVATE,
-                        Modifier.FINAL)
+                poetTypeName(),
+                KeyWordUtils.getKeyWordCompatibleName(camelCaseKey()),
+                Modifier.PRIVATE,
+                Modifier.FINAL)
                 .build());
     }
 
     @Value.Lazy
     default MethodSpec getterProperty() {
-        MethodSpec.Builder getterBuilder = MethodSpec.methodBuilder("get" + pascalCaseKey())
+        MethodSpec.Builder getterBuilder = MethodSpec
+                .methodBuilder(KeyWordUtils.getKeyWordCompatibleFunctionName(pascalCaseKey(), "get" + pascalCaseKey()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(poetTypeName());
         if (literalValue().isPresent()) {

--- a/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
+++ b/generator-utils/src/main/java/com/fern/java/generators/object/EnrichedObjectProperty.java
@@ -66,7 +66,7 @@ public interface EnrichedObjectProperty {
     @Value.Lazy
     default MethodSpec getterProperty() {
         MethodSpec.Builder getterBuilder = MethodSpec
-                .methodBuilder(KeyWordUtils.getKeyWordCompatibleFunctionName(pascalCaseKey(), "get" + pascalCaseKey()))
+                .methodBuilder(KeyWordUtils.getKeyWordCompatibleMethodName("get" + pascalCaseKey()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(poetTypeName());
         if (literalValue().isPresent()) {

--- a/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
+++ b/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
@@ -34,12 +34,15 @@ public final class KeyWordUtils {
             "assert",
             "switch");
 
+    private static final Set<String> RESERVED_METHOD_NAMES = Set.of(
+            "getClass");
+
     private KeyWordUtils() {
     }
 
-    public static String getKeyWordCompatibleFunctionName(String name, String funcName) {
-        if (isReserved(name.toLowerCase())) {
-            return "_" + funcName;
+    public static String getKeyWordCompatibleMethodName(String funcName) {
+        if (isReservedFunctionName(funcName)) {
+            return funcName + "_";
         }
         return funcName;
     }
@@ -53,5 +56,9 @@ public final class KeyWordUtils {
 
     public static boolean isReserved(String value) {
         return RESERVED_WORDS.contains(value.toLowerCase());
+    }
+
+    public static boolean isReservedFunctionName(String value) {
+        return RESERVED_METHOD_NAMES.contains(value);
     }
 }

--- a/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
+++ b/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
@@ -34,7 +34,15 @@ public final class KeyWordUtils {
             "assert",
             "switch");
 
-    private KeyWordUtils() {}
+    private KeyWordUtils() {
+    }
+
+    public static String getKeyWordCompatibleFunctionName(String name, String funcName) {
+        if (isReserved(name.toLowerCase())) {
+            return "_" + funcName;
+        }
+        return funcName;
+    }
 
     public static String getKeyWordCompatibleName(String name) {
         if (isReserved(name.toLowerCase())) {


### PR DESCRIPTION
Right now we have a list of reserved variables that we use to special case class variables, however we don't do the same for getters
I chose to just use the same reserved name list, but we might want to consider a reserved function name list instead (I just couldn't find one online), curious your take @dsinghvi 

I build a small test that seems to solve the issue Metriport is running into
```
types:
  BaseObject:
    properties:
      prop1: string
      prop2: string
  Account:
    properties: 
      class: BaseObject
      package: BaseObject
```